### PR TITLE
LibOVRIntegration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,7 @@ find_package(Magnum REQUIRED)
 
 # Parts of the library
 option(WITH_BULLET "Build BulletIntegration library" OFF)
+option(WITH_OVR "Build LibOvrIntegration library" OFF)
 
 include(CMakeDependentOption)
 option(BUILD_STATIC "Build static libraries (default are shared)" OFF)

--- a/doc/building-integration.dox
+++ b/doc/building-integration.dox
@@ -53,6 +53,7 @@ By default no integration libraries are built and you need to select them
 manually:
 
 -   `WITH_BULLET` -- @ref BulletIntegration "BulletIntegration" library.
+-   `WITH_OVR` -- @ref LibOvrIntegration "LibOvrIntegration" library.
 
 Note that [each <tt>*Integration</tt> namespace](namespaces.html) contains more
 detailed information about dependencies, availability on particular platform

--- a/doc/cmake-integration.dox
+++ b/doc/cmake-integration.dox
@@ -52,6 +52,7 @@ This command tries to find Magnum integration library and then defines:
 This command alone is useless without specifying the components:
 
 -   `Bullet` -- @ref BulletIntegration library
+-   `LibOvr` -- @ref LibOvrIntegration library
 
 Note that [each <tt>*Integration</tt> namespace](namespaces.html) contains more
 detailed information about dependencies, availability on particular platform

--- a/doc/namespaces.dox
+++ b/doc/namespaces.dox
@@ -36,7 +36,7 @@
 Conversion of matrix and vector classes, wrappers for rigid body dynamics.
 
 This library depends on **Bullet Physics** library and it is built if
-`WITH_BULLETINTEGRATION` is enabled when building Magnum Integration. To use
+`WITH_BULLET` is enabled when building Magnum Integration. To use
 this library, you need to request `Bullet` component of `MagnumIntegration`
 package in CMake, add `${MAGNUM_BULLETINTEGRATION_INCLUDE_DIRS}` to include
 path and link to `${MAGNUM_BULLETINTEGRATION_LIBRARIES}`. See

--- a/doc/namespaces.dox
+++ b/doc/namespaces.dox
@@ -42,3 +42,19 @@ package in CMake, add `${MAGNUM_BULLETINTEGRATION_INCLUDE_DIRS}` to include
 path and link to `${MAGNUM_BULLETINTEGRATION_LIBRARIES}`. See
 @ref building-integration and @ref cmake-integration for more information.
 */
+
+/** @dir Magnum/LibOvrIntegration
+ * @brief Namespace @ref Magnum::LibOvrIntegration
+ */
+/** @namespace Magnum::LibOvrIntegration
+@brief Integration with the Oculus SDK (LibOVR)
+
+Conversion of math classes, wrappers for most OVR CAPI structures and functions.
+
+This library depends on **Oculus SDK 0.6.0.0-beta** and is built if `WITH_OVR`
+is enabled when building Magnum Integration. To use this library, you need to
+request `LibOvr` component of `MagnumIntegration` package in CMake, add
+`${MAGNUM_LIBOVRINTEGRATION_INCLUDE_DIRS}` to include path and link to
+`${MAGNUM_LIBOVRINTEGRATION_LIBRARIES}`. See @ref building-integration and
+@ref cmake-integration for more information.
+*/

--- a/modules/FindMagnumIntegration.cmake
+++ b/modules/FindMagnumIntegration.cmake
@@ -6,6 +6,7 @@
 #  MAGNUMINTEGRATION_FOUND      - Whether the library was found
 # This command alone is useless without specifying the components:
 #  Bullet                       - Bullet Physics integration library
+#  LibOvr                       - LibOVR integration library
 # Example usage with specifying additional components is:
 #  find_package(MagnumIntegration [REQUIRED|COMPONENTS]
 #               Bullet)
@@ -113,6 +114,15 @@ foreach(component ${MagnumIntegration_FIND_COMPONENTS})
             set(_MAGNUM_${_COMPONENT}INTEGRATION_LIBRARIES ${BULLET_LIBRARIES})
             set(_MAGNUM_${_COMPONENT}INTEGRATION_INCLUDE_PATH_NAMES MotionState.h)
             set(_MAGNUM_${_COMPONENT}INTEGRATION_INCLUDE_DIRS ${BULLET_INCLUDE_DIRS})
+        else()
+            unset(MAGNUM_${_COMPONENT}INTEGRATION_LIBRARY)
+        endif()
+    elseif(${component} STREQUAL LibOvr)
+        find_package(OVR)
+        if(OVR_FOUND)
+            set(_MAGNUM_${_COMPONENT}INTEGRATION_LIBRARIES ${OVR_LIBRARIES})
+            set(_MAGNUM_${_COMPONENT}INTEGRATION_INCLUDE_PATH_NAMES LibOvrIntegration.h)
+            set(_MAGNUM_${_COMPONENT}INTEGRATION_INCLUDE_DIRS ${PVR_INCLUDE_DIRS})
         else()
             unset(MAGNUM_${_COMPONENT}INTEGRATION_LIBRARY)
         endif()

--- a/modules/FindOVR.cmake
+++ b/modules/FindOVR.cmake
@@ -1,0 +1,62 @@
+# - Find OVR
+#
+# This module defines:
+#
+#  OVR_FOUND                - True if OVR library is found
+#  OVR_LIBRARY              - OVR dynamic library
+#  OVR_INCLUDE_DIR          - Include dir
+#
+
+#
+#   This file is part of Magnum.
+#
+#   Copyright © 2010, 2011, 2012, 2013, 2014, 2015
+#             Vladimír Vondruš <mosra@centrum.cz>
+#   Copyright © 2015
+#             Jonathan Hale <squareys@googlemail.com>
+#
+#   Permission is hereby granted, free of charge, to any person obtaining a
+#   copy of this software and associated documentation files (the "Software"),
+#   to deal in the Software without restriction, including without limitation
+#   the rights to use, copy, modify, merge, publish, distribute, sublicense,
+#   and/or sell copies of the Software, and to permit persons to whom the
+#   Software is furnished to do so, subject to the following conditions:
+#
+#   The above copyright notice and this permission notice shall be included
+#   in all copies or substantial portions of the Software.
+#
+#   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+#   THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+#   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+#   FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+#   DEALINGS IN THE SOFTWARE.
+#
+
+set(LIBOVR_ROOT ${CMAKE_INSTALL_PREFIX})
+
+if(NOT OVR_SDK_ROOT)
+    message(WARNING "OVR_SDK_ROOT is not set. Will try to find headers and library in ${CMAKE_INSTALL_PREFIX}." )
+else()
+    set(LIBOVR_ROOT ${OVR_SDK_ROOT}/LibOVR)
+endif()
+
+# find include directory
+find_path(OVR_INCLUDE_DIR NAMES OVR_CAPI.h HINTS ${LIBOVR_ROOT}/Include)
+
+if(WIN32)
+    if(MSVC)
+        find_library(OVR_LIBRARY NAMES LibOVR HINTS ${LIBOVR_ROOT}/Lib/Windows)
+    elseif(MINGW)
+        # linking against the MSVC dll with MinGW does not work directly. Instead, you need to
+        # link against a specific version. This will cause problems with newer oculus runtimes,
+        # though. (FIXME!)
+        # The clean way to link against libOVR with mingw would be to compile the linux version,
+        # 0.6.0.0-beta is not available for Linux, though.
+        find_library(OVR_LIBRARY NAMES LibOVRRT32_0_6.dll HINTS "C:/Windows/SysWOW64")
+    endif()
+endif()
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(OVR OVR_LIBRARY OVR_INCLUDE_DIR)

--- a/src/Magnum/LibOvrIntegration/CMakeLists.txt
+++ b/src/Magnum/LibOvrIntegration/CMakeLists.txt
@@ -3,6 +3,8 @@
 #
 #   Copyright © 2010, 2011, 2012, 2013, 2014, 2015
 #             Vladimír Vondruš <mosra@centrum.cz>
+#   Copyright © 2015
+#             Jonathan Hale <squareys@googlemail.com>
 #
 #   Permission is hereby granted, free of charge, to any person obtaining a
 #   copy of this software and associated documentation files (the "Software"),
@@ -23,10 +25,45 @@
 #   DEALINGS IN THE SOFTWARE.
 #
 
-if(WITH_BULLET)
-    add_subdirectory(BulletIntegration)
-endif()
+cmake_minimum_required(VERSION 3.2)
+project(MagnumLibOvrIntegration LANGUAGES CXX)
 
-if(WITH_OVR)
-    add_subdirectory(LibOvrIntegration)
+find_package(Magnum REQUIRED)
+find_package(OVR REQUIRED)
+
+set(MagnumLibOvrIntegration_SRCS
+    Conversion.cpp
+    Context.cpp
+    Hmd.cpp
+    Compositor.cpp)
+
+set(MagnumLibOvrIntegration_HEADERS
+    LibOvrIntegration.h
+    Conversion.h
+    HmdEnum.h
+    Context.h
+    Hmd.h
+    Compositor.h
+
+    visibility.h)
+
+# LibOvrIntegration library
+add_library(MagnumLibOvrIntegration SHARED
+    ${MagnumLibOvrIntegration_SRCS}
+    ${MagnumLibOvrIntegration_HEADERS})
+set_target_properties(MagnumLibOvrIntegration PROPERTIES DEBUG_POSTFIX "-d")
+if(BUILD_STATIC_PIC)
+    set_target_properties(MagnumLibOvrIntegration PROPERTIES POSITION_INDEPENDENT_CODE ON)
+endif()
+target_link_libraries(MagnumLibOvrIntegration
+    ${MAGNUM_LIBRARIES}
+    ${OVR_LIBRARY})
+
+install(TARGETS MagnumLibOvrIntegration DESTINATION ${MAGNUM_LIBRARY_INSTALL_DIR}
+        RUNTIME DESTINATION bin
+        LIBRARY DESTINATION lib)
+install(FILES ${MagnumLibOvrIntegration_HEADERS} DESTINATION ${MAGNUM_INCLUDE_INSTALL_DIR}/LibOvrIntegration)
+
+if(BUILD_TESTS)
+    add_subdirectory(Test)
 endif()

--- a/src/Magnum/LibOvrIntegration/Compositor.cpp
+++ b/src/Magnum/LibOvrIntegration/Compositor.cpp
@@ -1,0 +1,122 @@
+/*
+    This file is part of Magnum.
+
+    Copyright © 2010, 2011, 2012, 2013, 2014, 2015
+              Vladimír Vondruš <mosra@centrum.cz>
+    Copyright © 2015
+              Jonathan Hale <squareys@googlemail.com>
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included
+    in all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+#include "Magnum/LibOVRIntegration/Compositor.h"
+
+#include "Magnum/LibOVRIntegration/Conversion.h"
+#include "Magnum/LibOVRIntegration/Hmd.h"
+
+#include <OVR_CAPI_GL.h>
+
+namespace Magnum { namespace LibOvrIntegration {
+
+Layer::Layer(const LayerType type): _layer(), _type(type) {
+    _layer.Header.Type = ovrLayerType(Corrade::Containers::EnumSet<LayerType>::UnderlyingType(_type));
+    _layer.Header.Flags = ovrLayerFlag_TextureOriginAtBottomLeft;
+}
+
+Layer& Layer::setEnabled(bool enabled) {
+    if(enabled) {
+        _layer.Header.Type = ovrLayerType(Corrade::Containers::EnumSet<LayerType>::UnderlyingType(_type));
+    } else {
+        _layer.Header.Type = ovrLayerType_Disabled;
+    }
+    return *this;
+}
+
+//----------------------------------------------------------------
+
+LayerEyeFov::LayerEyeFov(): Layer(LayerType::EyeFov) {
+}
+
+LayerEyeFov& LayerEyeFov::setColorTexture(const int eye, SwapTextureSet& textureSet) {
+    _layer.EyeFov.ColorTexture[eye] = &textureSet.getOvrSwapTextureSet();
+
+    return *this;
+}
+
+LayerEyeFov& LayerEyeFov::setViewport(const int eye, const Range2Di& viewport) {
+    _layer.EyeFov.Viewport[eye] = ovrRecti(viewport);
+
+    return *this;
+}
+
+LayerEyeFov& LayerEyeFov::setRenderPoses(const Hmd& hmd) {
+    _layer.EyeFov.RenderPose[0] = hmd._ovrPoses[0];
+    _layer.EyeFov.RenderPose[1] = hmd._ovrPoses[1];
+
+    return *this;
+}
+
+LayerEyeFov& LayerEyeFov::setFov(const Hmd& hmd) {
+    _layer.EyeFov.Fov[0] = hmd._hmd->DefaultEyeFov[0];
+    _layer.EyeFov.Fov[1] = hmd._hmd->DefaultEyeFov[1];
+
+    return *this;
+}
+
+//----------------------------------------------------------------
+
+Compositor::Compositor(): _layers(), _wrappedLayers() {
+}
+
+typedef Corrade::Containers::EnumSet<LayerType> LayerTypes;
+
+Layer& Compositor::addLayer(const LayerType type) {
+    switch (type) {
+        case LayerType::Direct:
+            CORRADE_ASSERT(false, "LayerType::Direct is not implemented.", addLayerEyeFov());
+            break;
+        case LayerType::EyeFov:
+            return addLayerEyeFov();
+        case LayerType::EyeFovDepth:
+            CORRADE_ASSERT(false, "LayerType::EyeFovDepth is not implemented.", addLayerEyeFov());
+            break;
+        case LayerType::QuadHeadLocked:
+            CORRADE_ASSERT(false, "LayerType::QuadHeadLocked is not implemented.", addLayerEyeFov());
+            break;
+        case LayerType::QuadInWorld:
+            CORRADE_ASSERT(false, "LayerType::QuadInWorld is not implemented.", addLayerEyeFov());
+            break;
+    }
+    CORRADE_ASSERT_UNREACHABLE();
+}
+
+LayerEyeFov& Compositor::addLayerEyeFov() {
+    _wrappedLayers.push_back(std::move(std::unique_ptr<Layer>(new LayerEyeFov())));
+    _layers.emplace_back(&_wrappedLayers.back().get()->layerHeader());
+
+    return *static_cast<LayerEyeFov*>(_wrappedLayers.back().get());
+}
+
+Compositor& Compositor::submitFrame(const Hmd& hmd) {
+    ovrHmd_SubmitFrame(hmd.getOvrHmd(), 0, &hmd.getOvrViewScale(), _layers.data(), _layers.size());
+
+    return *this;
+}
+
+}}

--- a/src/Magnum/LibOvrIntegration/Compositor.cpp
+++ b/src/Magnum/LibOvrIntegration/Compositor.cpp
@@ -166,13 +166,13 @@ LayerQuad& LayerQuad::setViewport(const Range2Di& viewport) {
     return *this;
 }
 
-LayerQuad& LayerQuad::setCenterPose(DualQuaternion pose) {
+LayerQuad& LayerQuad::setCenterPose(const DualQuaternion& pose) {
     _layer.Quad.QuadPoseCenter = ovrPosef(pose);
 
     return *this;
 }
 
-LayerQuad& LayerQuad::setQuadSize(Vector2 size) {
+LayerQuad& LayerQuad::setQuadSize(const Vector2& size) {
     _layer.Quad.QuadSize = ovrVector2f(size);
 
     return *this;

--- a/src/Magnum/LibOvrIntegration/Compositor.cpp
+++ b/src/Magnum/LibOvrIntegration/Compositor.cpp
@@ -229,8 +229,8 @@ LayerQuad& Compositor::addLayerQuadInWorld() {
     return static_cast<LayerQuad&>(addLayer(std::move(std::unique_ptr<Layer>(new LayerEyeFov()))));
 }
 
-Compositor& Compositor::submitFrame(const Hmd& hmd) {
-    ovrHmd_SubmitFrame(hmd.getOvrHmd(), 0, &hmd.getOvrViewScale(), _layers.data(), _layers.size());
+Compositor& Compositor::submitFrame(Hmd& hmd) {
+    ovrHmd_SubmitFrame(hmd.getOvrHmd(), hmd.incFrameIndex(), &hmd.getOvrViewScale(), _layers.data(), _layers.size());
 
     return *this;
 }

--- a/src/Magnum/LibOvrIntegration/Compositor.h
+++ b/src/Magnum/LibOvrIntegration/Compositor.h
@@ -430,7 +430,7 @@ class MAGNUM_LIBOVRINTEGRATION_EXPORT Compositor {
          * @param hmd Hmd to render to.
          * @return Reference to self (for method chaining)
          */
-        Compositor& submitFrame(const Hmd& hmd);
+        Compositor& submitFrame(Hmd& hmd);
 
     private:
 

--- a/src/Magnum/LibOvrIntegration/Compositor.h
+++ b/src/Magnum/LibOvrIntegration/Compositor.h
@@ -1,0 +1,227 @@
+#ifndef Magnum_LibOvrIntegration_Compositor_h
+#define Magnum_LibOvrIntegration_Compositor_h
+/*
+    This file is part of Magnum.
+
+    Copyright © 2010, 2011, 2012, 2013, 2014, 2015
+              Vladimír Vondruš <mosra@centrum.cz>
+    Copyright © 2015
+              Jonathan Hale <squareys@googlemail.com>
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included
+    in all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+/** @file
+ * @brief Class @ref Magnum::LibOvrIntegration::Compositor,
+ *        class @ref Magnum::LibOvrIntegration::Layer,
+ *        class @ref Magnum::LibOvrIntegration::EyeFovLayer,
+ *        enum @ref Magnum::LibOvrIntegration::LayerType
+ *
+ * @author Jonathan Hale (Squareys)
+ */
+
+#include <Magnum/Magnum.h>
+
+#include <memory>
+#include <vector>
+
+#include "Magnum/LibOvrIntegration/visibility.h"
+#include "Magnum/LibOvrIntegration/LibOvrIntegration.h"
+
+#include <OVR_CAPI.h>
+
+namespace Magnum { namespace LibOvrIntegration {
+
+enum class LayerType: UnsignedByte {
+
+    /** @brief Described by ovrLayerEyeFov. */
+    EyeFov = ovrLayerType_EyeFov,
+
+    /** @brief Described by ovrLayerEyeFovDepth. */
+    EyeFovDepth = ovrLayerType_EyeFovDepth,
+
+    /** @brief Described by ovrLayerQuad. */
+    QuadInWorld = ovrLayerType_QuadInWorld,
+
+    /** @brief Described by ovrLayerQuad. Displayed in front of your face, moving with the head. */
+    QuadHeadLocked = ovrLayerType_QuadHeadLocked,
+
+    /** @brief Described by ovrLayerDirect. Passthrough for debugging and custom rendering. */
+    Direct = ovrLayerType_Direct
+
+};
+
+/**
+ * @brief Wrapper around an ovrLayerHeader.
+ *
+ * If you need to be able to change the layer, use one of the type specific
+ * layer classes instead: @ref LayerEyeFov
+ *
+ * @author Jonathan Hale (Squareys)
+ */
+class MAGNUM_LIBOVRINTEGRATION_EXPORT Layer {
+    public:
+        /**
+         * @brief Contructor.
+         * @param type Type of this layer.
+         */
+        explicit Layer(const LayerType type);
+
+        /** @brief Copying is not allowed. */
+        Layer(const Layer& context) = delete;
+        Layer& operator=(const Layer&) = delete;
+
+        /**
+         * @brief Set whether to process this layer in high quality.
+         *
+         * High quality mode costs performance, but looks better.
+         *
+         * @param b If true, layer will be in high quality mode, if false, the
+         *          layer will be in lower quality mode.
+         * @return Reference to self (for method chaining)
+         */
+        Layer& setHighQuality(bool highQuality) {
+            if(highQuality) {
+                _layer.Header.Flags |= ovrLayerFlag_HighQuality;
+            } else {
+                _layer.Header.Flags &= ~ovrLayerFlag_HighQuality;
+            }
+            return *this;
+        }
+
+        /**
+         * @brief Enable/disable a the layer.
+         * @param enabled If true, the layer will be enabled.
+         * @return Reference to self (for method chaining)
+         */
+        Layer& setEnabled(bool enabled);
+
+        /** @brief Type of this layer. */
+        LayerType layerType() const {
+            return _type;
+        }
+
+        /** @brief The underlying ovrLayerHeader. */
+        const ovrLayerHeader& layerHeader() const {
+            return _layer.Header;
+        }
+
+    protected:
+        ovrLayer_Union _layer;
+
+    private:
+        const LayerType _type;
+
+        friend class Compositor;
+};
+
+/**
+ * @brief Wrapper around ovrLayerEveFov.
+ * @author Jonathan Hale (Squareys)
+ */
+class MAGNUM_LIBOVRINTEGRATION_EXPORT LayerEyeFov: public Layer {
+    public:
+        /** @brief Constructor. */
+
+    explicit LayerEyeFov();
+        /** @brief Copying is not allowed. */
+        LayerEyeFov(const LayerEyeFov& context) = delete;
+
+        /**
+         * @brief Set color texture.
+         * @param eye Index of the eye the color texture is set for.
+         * @param textureSet @ref SwapTextureSet to set as color texture.
+         * @return Reference to self (for method chaining)
+         */
+        LayerEyeFov& setColorTexture(const int eye, SwapTextureSet& textureSet);
+
+        /**
+         * @brief Set the viewport.
+         * @param eye Eye index to set the viewport for.
+         * @param viewport Viewport to set to.
+         * @return Reference to self (for method chaining)
+         */
+        LayerEyeFov& setViewport(const int eye, const Range2Di& viewport);
+
+        /**
+         * @brief Set the render pose.
+         * @param hmd Hmd to get the render pose from.
+         * @return Reference to self (for method chaining)
+         */
+        LayerEyeFov& setRenderPoses(const Hmd& hmd);
+
+        /**
+         * @brief Set fov for this layer.
+         * @param hmd Hmd to get the default eye fov to set to.
+         * @return Reference to self (for method chaining)
+         */
+        LayerEyeFov& setFov(const Hmd& hmd);
+
+};
+
+/**
+@brief Compositor
+
+Wraps compositing related functions of LibOVR.
+
+@todoc Usage...
+
+@author Jonathan Hale (Squareys)
+*/
+class MAGNUM_LIBOVRINTEGRATION_EXPORT Compositor {
+    public:
+        /* @brief Copying is not allowed. */
+        Compositor(const Compositor&) = delete;
+
+        /* @brief Moving is not allowed. */
+        Compositor(Compositor&&) = delete;
+
+        /**
+         * @brief Add a layer of specific type.
+         * @param type Layer type.
+         * @return Reference to the created layer.
+         */
+        Layer& addLayer(const LayerType type);
+
+        /**
+         * @brief Create a @ref LayerEyeFov.
+         * @return Reference to the created layer.
+         */
+        LayerEyeFov& addLayerEyeFov();
+
+        /**
+         * @brief Submit the frame to the compositor.
+         * @param hmd Hmd to render to.
+         * @return Reference to self (for method chaining)
+         */
+        Compositor& submitFrame(const Hmd& hmd);
+
+    private:
+
+        explicit Compositor();
+
+        std::vector<const ovrLayerHeader*> _layers;
+        std::vector<std::unique_ptr<Layer>> _wrappedLayers;
+
+        friend class LibOvrContext;
+};
+
+}}
+
+#endif

--- a/src/Magnum/LibOvrIntegration/Compositor.h
+++ b/src/Magnum/LibOvrIntegration/Compositor.h
@@ -132,16 +132,16 @@ class MAGNUM_LIBOVRINTEGRATION_EXPORT Layer {
 };
 
 /**
- * @brief Wrapper around ovrLayerEveFov.
+ * @brief Wrapper around ovrLayerDirect.
  * @author Jonathan Hale (Squareys)
  */
-class MAGNUM_LIBOVRINTEGRATION_EXPORT LayerEyeFov: public Layer {
+class MAGNUM_LIBOVRINTEGRATION_EXPORT LayerDirect: public Layer {
     public:
         /** @brief Constructor. */
+        explicit LayerDirect();
 
-    explicit LayerEyeFov();
         /** @brief Copying is not allowed. */
-        LayerEyeFov(const LayerEyeFov& context) = delete;
+        LayerDirect(const LayerDirect&) = delete;
 
         /**
          * @brief Set color texture.
@@ -149,7 +149,37 @@ class MAGNUM_LIBOVRINTEGRATION_EXPORT LayerEyeFov: public Layer {
          * @param textureSet @ref SwapTextureSet to set as color texture.
          * @return Reference to self (for method chaining)
          */
-        LayerEyeFov& setColorTexture(const int eye, SwapTextureSet& textureSet);
+        LayerDirect& setColorTexture(const int eye, const SwapTextureSet& textureSet);
+
+        /**
+         * @brief Set the viewport.
+         * @param eye Eye index to set the viewport for.
+         * @param viewport Viewport to set to.
+         * @return Reference to self (for method chaining)
+         */
+        LayerDirect& setViewport(const int eye, const Range2Di& viewport);
+
+};
+
+/**
+ * @brief Wrapper around ovrLayerEveFov.
+ * @author Jonathan Hale (Squareys)
+ */
+class MAGNUM_LIBOVRINTEGRATION_EXPORT LayerEyeFov: public Layer {
+    public:
+        /** @brief Constructor. */
+        explicit LayerEyeFov();
+
+        /** @brief Copying is not allowed. */
+        LayerEyeFov(const LayerEyeFov&) = delete;
+
+        /**
+         * @brief Set color texture.
+         * @param eye Index of the eye the color texture is set for.
+         * @param textureSet @ref SwapTextureSet to set as color texture.
+         * @return Reference to self (for method chaining)
+         */
+        LayerEyeFov& setColorTexture(const int eye, const SwapTextureSet& textureSet);
 
         /**
          * @brief Set the viewport.
@@ -172,6 +202,121 @@ class MAGNUM_LIBOVRINTEGRATION_EXPORT LayerEyeFov: public Layer {
          * @return Reference to self (for method chaining)
          */
         LayerEyeFov& setFov(const Hmd& hmd);
+
+};
+
+class MAGNUM_LIBOVRINTEGRATION_EXPORT TimewarpProjectionDescription {
+    public:
+        explicit TimewarpProjectionDescription(const Matrix4& projectionMatrix);
+
+        const ovrTimewarpProjectionDesc& getOvrTimewarpProjectionDesc() const {
+            return _projectionDesc;
+        }
+
+    private:
+        ovrTimewarpProjectionDesc _projectionDesc;
+};
+
+/**
+ * @brief Wrapper around ovrLayerEveFovDepth.
+ * @author Jonathan Hale (Squareys)
+ */
+class MAGNUM_LIBOVRINTEGRATION_EXPORT LayerEyeFovDepth: public Layer {
+    public:
+        /** @brief Constructor. */
+        explicit LayerEyeFovDepth();
+
+        /** @brief Copying is not allowed. */
+        LayerEyeFovDepth(const LayerEyeFovDepth&) = delete;
+
+        /**
+         * @brief Set color texture.
+         * @param eye Index of the eye the color texture is set for.
+         * @param textureSet @ref SwapTextureSet to set as color texture.
+         * @return Reference to self (for method chaining)
+         */
+        LayerEyeFovDepth& setColorTexture(const int eye, const SwapTextureSet& textureSet);
+
+        /**
+         * @brief Set the viewport.
+         * @param eye Eye index to set the viewport for.
+         * @param viewport Viewport to set to.
+         * @return Reference to self (for method chaining)
+         */
+        LayerEyeFovDepth& setViewport(const int eye, const Range2Di& viewport);
+
+        /**
+         * @brief Set the render pose.
+         * @param hmd Hmd to get the render pose from.
+         * @return Reference to self (for method chaining)
+         */
+        LayerEyeFovDepth& setRenderPoses(const Hmd& hmd);
+
+        /**
+         * @brief Set fov for this layer.
+         * @param hmd Hmd to get the default eye fov to set to.
+         * @return Reference to self (for method chaining)
+         */
+        LayerEyeFovDepth& setFov(const Hmd& hmd);
+
+        /**
+         * @brief Set depth texture.
+         * @param eye Index of the eye the depth texture is set for.
+         * @param textureSet @ref SwapTextureSet to set as depth texture.
+         * @return Reference to self (for method chaining)
+         */
+        LayerEyeFovDepth& setDepthTexture(const int eye, const SwapTextureSet& textureSet);
+
+        /**
+         * @brief setTimewarpProjectionDesc
+         * @return Reference to self (for method chaining)
+         */
+        LayerEyeFovDepth& setTimewarpProjDesc(const TimewarpProjectionDescription& desc);
+};
+
+/**
+ * @brief Wrapper around ovrLayerQuad.
+ * @author Jonathan Hale (Squareys)
+ * @see @ref ovrLayerQuad
+ */
+class MAGNUM_LIBOVRINTEGRATION_EXPORT LayerQuad: public Layer {
+    public:
+        /** @brief Constructor. */
+        explicit LayerQuad(bool headLocked = false);
+
+        /** @brief Copying is not allowed. */
+        LayerQuad(const LayerQuad&) = delete;
+
+        /**
+         * @brief Set color texture.
+         * @param textureSet @ref SwapTextureSet to set as color texture.
+         * @return Reference to self (for method chaining)
+         */
+        LayerQuad& setColorTexture(const SwapTextureSet& textureSet);
+
+        /**
+         * @brief Set the viewport.
+         * @param viewport Viewport to set to.
+         * @return Reference to self (for method chaining)
+         */
+        LayerQuad& setViewport(const Range2Di& viewport);
+
+        /**
+         * @brief Set position and orientation of the center of the quad.
+         *
+         * Position is specified in meters.
+         *
+         * @param pose Center pose of the quad.
+         * @return Reference to self (for method chaining)
+         */
+        LayerQuad& setCenterPose(DualQuaternion pose);
+
+        /**
+         * @brief Set width and heigh of the quad in meters.
+         * @param size Size of the quad.
+         * @return Reference to self (for method chaining)
+         */
+        LayerQuad& setQuadSize(Vector2 size);
 
 };
 
@@ -200,10 +345,34 @@ class MAGNUM_LIBOVRINTEGRATION_EXPORT Compositor {
         Layer& addLayer(const LayerType type);
 
         /**
+         * @brief Create a @ref LayerDirect.
+         * @return Reference to the created layer.
+         */
+        LayerDirect& addLayerDirect();
+
+        /**
          * @brief Create a @ref LayerEyeFov.
          * @return Reference to the created layer.
          */
         LayerEyeFov& addLayerEyeFov();
+
+        /**
+         * @brief Create a @ref LayerEyeFovDepth.
+         * @return Reference to the created layer.
+         */
+        LayerEyeFovDepth& addLayerEyeFovDepth();
+
+        /**
+         * @brief Create a @ref LayerQuad with @ref LayerType::QuadHeadLocked.
+         * @return Reference to the created layer.
+         */
+        LayerQuad& addLayerQuadHeadLocked();
+
+        /**
+         * @brief Create a @ref LayerQuad with @ref LayerType::QuadInWorld.
+         * @return Reference to the created layer.
+         */
+        LayerQuad& addLayerQuadInWorld();
 
         /**
          * @brief Submit the frame to the compositor.
@@ -215,6 +384,8 @@ class MAGNUM_LIBOVRINTEGRATION_EXPORT Compositor {
     private:
 
         explicit Compositor();
+
+        Layer& addLayer(std::unique_ptr<Layer> layer);
 
         std::vector<const ovrLayerHeader*> _layers;
         std::vector<std::unique_ptr<Layer>> _wrappedLayers;

--- a/src/Magnum/LibOvrIntegration/Compositor.h
+++ b/src/Magnum/LibOvrIntegration/Compositor.h
@@ -154,7 +154,7 @@ class MAGNUM_LIBOVRINTEGRATION_EXPORT LayerDirect: public Layer {
          * @param textureSet @ref SwapTextureSet to set as color texture.
          * @return Reference to self (for method chaining)
          */
-        LayerDirect& setColorTexture(const int eye, const SwapTextureSet& textureSet);
+        LayerDirect& setColorTexture(int eye, const SwapTextureSet& textureSet);
 
         /**
          * @brief Set the viewport.
@@ -162,7 +162,7 @@ class MAGNUM_LIBOVRINTEGRATION_EXPORT LayerDirect: public Layer {
          * @param viewport Viewport to set to.
          * @return Reference to self (for method chaining)
          */
-        LayerDirect& setViewport(const int eye, const Range2Di& viewport);
+        LayerDirect& setViewport(int eye, const Range2Di& viewport);
 
 };
 
@@ -184,7 +184,7 @@ class MAGNUM_LIBOVRINTEGRATION_EXPORT LayerEyeFov: public Layer {
          * @param textureSet @ref SwapTextureSet to set as color texture.
          * @return Reference to self (for method chaining)
          */
-        LayerEyeFov& setColorTexture(const int eye, const SwapTextureSet& textureSet);
+        LayerEyeFov& setColorTexture(int eye, const SwapTextureSet& textureSet);
 
         /**
          * @brief Set the viewport.
@@ -192,7 +192,7 @@ class MAGNUM_LIBOVRINTEGRATION_EXPORT LayerEyeFov: public Layer {
          * @param viewport Viewport to set to.
          * @return Reference to self (for method chaining)
          */
-        LayerEyeFov& setViewport(const int eye, const Range2Di& viewport);
+        LayerEyeFov& setViewport(int eye, const Range2Di& viewport);
 
         /**
          * @brief Set the render pose.
@@ -250,7 +250,7 @@ class MAGNUM_LIBOVRINTEGRATION_EXPORT LayerEyeFovDepth: public Layer {
          * @param textureSet @ref SwapTextureSet to set as color texture.
          * @return Reference to self (for method chaining)
          */
-        LayerEyeFovDepth& setColorTexture(const int eye, const SwapTextureSet& textureSet);
+        LayerEyeFovDepth& setColorTexture(int eye, const SwapTextureSet& textureSet);
 
         /**
          * @brief Set the viewport.
@@ -258,7 +258,7 @@ class MAGNUM_LIBOVRINTEGRATION_EXPORT LayerEyeFovDepth: public Layer {
          * @param viewport Viewport to set to.
          * @return Reference to self (for method chaining)
          */
-        LayerEyeFovDepth& setViewport(const int eye, const Range2Di& viewport);
+        LayerEyeFovDepth& setViewport(int eye, const Range2Di& viewport);
 
         /**
          * @brief Set the render pose.
@@ -280,7 +280,7 @@ class MAGNUM_LIBOVRINTEGRATION_EXPORT LayerEyeFovDepth: public Layer {
          * @param textureSet @ref SwapTextureSet to set as depth texture.
          * @return Reference to self (for method chaining)
          */
-        LayerEyeFovDepth& setDepthTexture(const int eye, const SwapTextureSet& textureSet);
+        LayerEyeFovDepth& setDepthTexture(int eye, const SwapTextureSet& textureSet);
 
         /**
          * @brief setTimewarpProjectionDesc
@@ -323,14 +323,14 @@ class MAGNUM_LIBOVRINTEGRATION_EXPORT LayerQuad: public Layer {
          * @param pose Center pose of the quad.
          * @return Reference to self (for method chaining)
          */
-        LayerQuad& setCenterPose(DualQuaternion pose);
+        LayerQuad& setCenterPose(const DualQuaternion& pose);
 
         /**
          * @brief Set width and heigh of the quad in meters.
          * @param size Size of the quad.
          * @return Reference to self (for method chaining)
          */
-        LayerQuad& setQuadSize(Vector2 size);
+        LayerQuad& setQuadSize(const Vector2& size);
 
 };
 
@@ -393,7 +393,7 @@ class MAGNUM_LIBOVRINTEGRATION_EXPORT Compositor {
          * @param type Layer type.
          * @return Reference to the created layer.
          */
-        Layer& addLayer(const LayerType type);
+        Layer& addLayer(LayerType type);
 
         /**
          * @brief Create a @ref LayerDirect.

--- a/src/Magnum/LibOvrIntegration/Context.cpp
+++ b/src/Magnum/LibOvrIntegration/Context.cpp
@@ -1,0 +1,85 @@
+/*
+    This file is part of Magnum.
+
+    Copyright © 2010, 2011, 2012, 2013, 2014, 2015
+              Vladimír Vondruš <mosra@centrum.cz>
+    Copyright © 2015
+              Jonathan Hale <squareys@googlemail.com>
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included
+    in all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+#include "Magnum/LibOvrIntegration/Context.h"
+
+#include "Magnum/LibOvrIntegration/Hmd.h"
+#include "Magnum/LibOvrIntegration/HmdEnum.h"
+
+#include <OVR_CAPI_GL.h>
+
+namespace Magnum { namespace LibOvrIntegration {
+
+LibOvrContext* LibOvrContext::_instance = nullptr;
+
+LibOvrContext::LibOvrContext() : _compositor() {
+    CORRADE_ASSERT(_instance == nullptr, "Another instance of LibOvrContext already exists.", );
+
+    _instance = this;
+    ovr_Initialize(nullptr);
+}
+
+LibOvrContext::~LibOvrContext() {
+    ovr_Shutdown();
+
+    _instance = nullptr;
+}
+
+LibOvrContext& LibOvrContext::get() {
+    CORRADE_ASSERT(_instance != nullptr,
+                   "No instance of LibOvrContext for ::get() exists.",
+                   *LibOvrContext::_instance);
+
+    return *LibOvrContext::_instance;
+}
+
+int LibOvrContext::detect() const {
+    return ovrHmd_Detect();
+}
+
+std::unique_ptr<Hmd> LibOvrContext::createHmd(int index, HmdType debugType) {
+    /* check if index is valid */
+    if(index >= 0 && detect() > index) {
+        ovrHmd hmd;
+        ovrHmd_Create(index, &hmd);
+        return std::unique_ptr<Hmd>(new Hmd(hmd, {}));
+    } else if(debugType != HmdType::None){
+        /* create a debug hmd instead of connecting to a device */
+        return createDebugHmd(debugType);
+    }
+
+    return std::unique_ptr<Hmd>();
+}
+
+std::unique_ptr<Hmd> LibOvrContext::createDebugHmd(HmdType debugType) {
+    ovrHmd hmd;
+    ovrHmd_CreateDebug(ovrHmdType(Corrade::Containers::EnumSet<HmdType>::UnderlyingType(debugType)), &hmd);
+
+    return std::unique_ptr<Hmd>(new Hmd(hmd, HmdStatusFlag::Debug));
+}
+
+}}

--- a/src/Magnum/LibOvrIntegration/Context.h
+++ b/src/Magnum/LibOvrIntegration/Context.h
@@ -1,0 +1,119 @@
+#ifndef Magnum_LibOvrIntegration_Context_h
+#define Magnum_LibOvrIntegration_Context_h
+/*
+    This file is part of Magnum.
+
+    Copyright © 2010, 2011, 2012, 2013, 2014, 2015
+              Vladimír Vondruš <mosra@centrum.cz>
+    Copyright © 2015
+              Jonathan Hale <squareys@googlemail.com>
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included
+    in all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+/** @file
+ * @brief Class @ref Magnum::LibOvrIntegration::OVRTextureUtil,
+ *        enum @ref Magnum::LibOvrIntegration::LibOvrContextStatusFlag
+ *
+ * @author Jonathan Hale (Squareys)
+ */
+
+#include <memory>
+
+#include <Magnum/Texture.h>
+
+#include "Magnum/LibOVRIntegration/visibility.h"
+#include "Magnum/LibOVRIntegration/LibOvrIntegration.h"
+#include "Magnum/LibOVRIntegration/Hmd.h" /* required for std::unique_ptr */
+#include "Magnum/LibOVRIntegration/Compositor.h"
+
+namespace Magnum { namespace LibOvrIntegration {
+
+/**
+@brief Singleton class LibOvrContext.
+
+Context for the LibOvrIntegration, gateway to connecting devices and
+creating @ref Hmd.
+
+@see @ref Hmd, @ref SwapTextureSet
+
+@todoc Usage...
+
+@author Jonathan Hale (Squareys)
+*/
+class MAGNUM_LIBOVRINTEGRATION_EXPORT LibOvrContext {
+    public:
+
+        /** @brief Constructor. */
+        explicit LibOvrContext();
+
+        /** @brief Copying is not allowed. */
+        LibOvrContext(const LibOvrContext& context) = delete;
+
+        /** @brief Moving is not allowed. */
+        LibOvrContext(LibOvrContext&& context) = delete;
+
+        /** @brief Destructor. */
+        ~LibOvrContext();
+
+        /**
+         * @brief Get the instance of the LibOvrContext.
+         * @return the context.
+         */
+         static LibOvrContext& get();
+
+        /**
+         * @brief Detect how many devices are currently connected.
+         * @return number of connected devices.
+         */
+        int detect() const;
+
+        /**
+         * @brief Create a handle to a connected hmd device.
+         * @param index Index of the device, must be greater than 0 and smaller than @ref #detect()
+         * @param debugType If not @ref HmdType::None, this device type will be used for a debug hmd
+         *        in case a real connection cannot be established.
+         * @return A @ref std::unique_pointer to the hmd at the given index (if exists), or a debug hmd,
+         *         if debugType is not specified as @ref HmdType::None, in which case the alternate return
+         *         value is an empty @ref std::unique_pointer.
+         */
+        std::unique_ptr<Hmd> createHmd(int index, HmdType debugType);
+
+        /**
+         * @brief Create a hmd handle which is not connected to an actual device.
+         * @param debugType Type of device to create a debug handle to.
+         * @return A @ref std::unique_pointer to the debug hmd.
+         */
+        std::unique_ptr<Hmd> createDebugHmd(HmdType debugType);
+
+        /**
+         * @return Reference to the compositor.
+         */
+        Compositor& compositor() {
+            return _compositor;
+        }
+
+    private:
+        static LibOvrContext* _instance;
+        Compositor _compositor;
+};
+
+}}
+
+#endif

--- a/src/Magnum/LibOvrIntegration/Context.h
+++ b/src/Magnum/LibOvrIntegration/Context.h
@@ -48,14 +48,26 @@ namespace Magnum { namespace LibOvrIntegration {
 /**
 @brief Singleton class LibOvrContext.
 
-Context for the LibOvrIntegration, gateway to connecting devices and
-creating @ref Hmd.
+LibOvrContext handles connection to devices, creation of debug Hmds and provides
+access to the oculus SDK compositor.
 
-@see @ref Hmd, @ref SwapTextureSet
+## Usage
 
-@todoc Usage...
+There should always only be one instance of LibOvrContext. As soon as this one
+instance is created, you can access it via @ref LibOvrContext::get().compositor()
+
+Example:
+
+@code
+LibOvrContext context;
+
+// ...
+
+LibOvrContext::get().detect();
+@endcode
 
 @author Jonathan Hale (Squareys)
+@see @ref Hmd, @ref Compositor
 */
 class MAGNUM_LIBOVRINTEGRATION_EXPORT LibOvrContext {
     public:

--- a/src/Magnum/LibOvrIntegration/Conversion.cpp
+++ b/src/Magnum/LibOvrIntegration/Conversion.cpp
@@ -1,0 +1,43 @@
+/*
+    This file is part of Magnum.
+
+    Copyright © 2010, 2011, 2012, 2013, 2014, 2015
+              Vladimír Vondruš <mosra@centrum.cz>
+    Copyright © 2015
+              Jonathan Hale <squareys@googlemail.com>
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included
+    in all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+#include "Magnum/LibOVRIntegration/Conversion.h"
+
+#include <OVR_CAPI_GL.h>
+
+namespace Magnum { namespace LibOvrIntegration {
+
+Texture2D wrap(const ovrTexture& texture) {
+    CORRADE_ASSERT(texture.Header.API == ovrRenderAPI_OpenGL,
+                   "The ovrTexture passed to OVRTextureUtil::wrap is not a GL texture.",
+                   Texture2D());
+
+    const ovrGLTexture* tex = reinterpret_cast<const ovrGLTexture*>(&texture);
+    return Texture2D::wrap(tex->OGL.TexId);
+}
+
+}}

--- a/src/Magnum/LibOvrIntegration/Conversion.h
+++ b/src/Magnum/LibOvrIntegration/Conversion.h
@@ -1,0 +1,157 @@
+#ifndef Magnum_LibOvrIntegration_Conversion_h
+#define Magnum_LibOvrIntegration_Conversion_h
+/*
+    This file is part of Magnum.
+
+    Copyright © 2010, 2011, 2012, 2013, 2014, 2015
+              Vladimír Vondruš <mosra@centrum.cz>
+    Copyright © 2015
+              Jonathan Hale <squareys@googlemail.com>
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included
+    in all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+/** @file
+ * @brief Converters and conversion methods.
+ *
+ * This header contains tools for converting libOVR types to magnum types.
+ *
+ * @author Jonathan Hale (Squareys)
+ */
+
+#include <OVR_CAPI.h>
+
+#include <Magnum/Magnum.h>
+#include <Magnum/Texture.h>
+#include <Magnum/Math/Range.h>
+#include <Magnum/Math/Vector.h>
+#include <Magnum/Math/Matrix4.h>
+#include <Magnum/Math/Quaternion.h>
+#include <Magnum/Math/DualQuaternion.h>
+
+namespace Magnum { namespace Math { namespace Implementation {
+
+/* ovrSizei */
+template<> struct VectorConverter<2, Int, ovrSizei> {
+    static Vector<2, Int> from(const ovrSizei& other) {
+        return {other.w, other.h};
+    }
+
+    static ovrSizei to(const Vector<2, Int>& other) {
+        return {other[0], other[1]};
+    }
+};
+
+
+/* ovrVector2i */
+template<> struct VectorConverter<2, Int, ovrVector2i> {
+    static Vector<2, Int> from(const ovrVector2i& other) {
+        return {other.x, other.y};
+    }
+
+    static ovrVector2i to(const Vector<2, Int>& other) {
+        return {other[0], other[1]};
+    }
+};
+
+/* ovrVector2f */
+template<> struct VectorConverter<2, Float, ovrVector2f> {
+    static Vector<2, Float> from(const ovrVector2f& other) {
+        return {other.x, other.y};
+    }
+
+    static ovrVector2f to(const Vector<2, Float>& other) {
+        return {other[0], other[1]};
+    }
+};
+
+/* ovrVector3f */
+template<> struct VectorConverter<3, Float, ovrVector3f> {
+    static Vector<3, Float> from(const ovrVector3f& other) {
+        return {other.x, other.y, other.z};
+    }
+
+    static ovrVector3f to(const Vector<3, Float>& other) {
+        return {other[0], other[1], other[2]};
+    }
+};
+
+/* ovrMatrix4
+ *
+ * The oculus SDK stores matrices in row-major form. We transpose to get column-major
+ * form for magnum and opengl. */
+template<> struct RectangularMatrixConverter<4, 4, Float, ovrMatrix4f> {
+    static RectangularMatrix<4, 4, Float> from(const ovrMatrix4f& other) {
+        return Matrix4<Float>::from(reinterpret_cast<const Float*>(other.M)).transposed();
+    }
+
+    static ovrMatrix4f to(const RectangularMatrix<4, 4, Float>& other) {
+        return *reinterpret_cast<ovrMatrix4f*>(other.transposed().data());
+    }
+};
+
+/* ovrQuatf */
+template<> struct QuaternionConverter<Float, ovrQuatf> {
+    static Quaternion<Float> from(const ovrQuatf& other) {
+        return Quaternion<Float>(Vector3<Float>{other.x, other.y, other.z}, other.w);
+    }
+
+    static ovrQuatf to(const Quaternion<Float>& other) {
+        const Vector3<Float> imaginary = other.vector();
+        return {imaginary.x(), imaginary.y(), imaginary.z(), other.scalar()};
+    }
+};
+
+/* ovrPosef */
+template<> struct DualQuaternionConverter<Float, ovrPosef> {
+    static DualQuaternion<Float> from(const ovrPosef& other) {
+        return DualQuaternion<Float>::translation(Vector3<Float>(other.Position)) * DualQuaternion<Float>{Quaternion<Float>(other.Orientation)};
+    }
+
+    static ovrPosef to(const DualQuaternion<Float>& other) {
+        return {ovrQuatf(other.rotation()), ovrVector3f(other.translation())};
+    }
+};
+
+/* ovrRecti */
+template<> struct RangeConverter<2, Int, ovrRecti> {
+    static Range<2, Int> from(const ovrRecti& other) {
+        return Range<2, Int>::fromSize(Vector2i(other.Pos), Vector2i(other.Size));
+    }
+
+    static ovrRecti to(const Range<2, Int>& other) {
+        return {ovrVector2i(other.min()), ovrSizei(other.size())};
+    }
+};
+
+}}
+
+namespace LibOvrIntegration {
+
+/* ovrTexture */
+/**
+ * @brief Wrap an ovrTexture as @ref Texture2D.
+ * @param texture @ref ovrTexture to wrap.
+ * @return texture as @ref Texture2D.
+ */
+Texture2D wrap(const ovrTexture& texture);
+
+}}
+
+#endif

--- a/src/Magnum/LibOvrIntegration/Hmd.cpp
+++ b/src/Magnum/LibOvrIntegration/Hmd.cpp
@@ -109,7 +109,7 @@ Vector2i Hmd::getFovTextureSize(const unsigned int eye) {
     return Vector2i(ovrHmd_GetFovTextureSize(_hmd, ovrEyeType(eye), _hmd->DefaultEyeFov[eye], 1.0));
 }
 
-Texture2D& Hmd::createMirrorTexture(TextureFormat format, Vector2i size) {
+Texture2D& Hmd::createMirrorTexture(const TextureFormat format, const Vector2i& size) {
     CORRADE_ASSERT(!(_flags & HmdStatusFlag::HasMirrorTexture),
            "Hmd::createMirrorTexture may only be called once, returning result of previous call.",
             *_mirrorTexture);
@@ -132,11 +132,11 @@ Texture2D& Hmd::createMirrorTexture(TextureFormat format, Vector2i size) {
     return *_mirrorTexture;
 }
 
-std::unique_ptr<SwapTextureSet> Hmd::createSwapTextureSet(TextureFormat format, int eye) {
+std::unique_ptr<SwapTextureSet> Hmd::createSwapTextureSet(TextureFormat format, const int eye) {
     return std::unique_ptr<SwapTextureSet>(new SwapTextureSet(*this, format, getFovTextureSize(eye)));
 }
 
-std::unique_ptr<SwapTextureSet> Hmd::createSwapTextureSet(TextureFormat format, const Vector2i size) {
+std::unique_ptr<SwapTextureSet> Hmd::createSwapTextureSet(TextureFormat format, const Vector2i& size) {
     return std::unique_ptr<SwapTextureSet>(new SwapTextureSet(*this, format, size));
 }
 
@@ -146,7 +146,7 @@ Matrix4 Hmd::projectionMatrix(const unsigned int eye, Float n, Float f) const {
     return Matrix4(proj);
 }
 
-Matrix4 Hmd::orthoSubProjectionMatrix(const unsigned int eye, const Matrix4& proj, Vector2 scale, Float distance) const {
+Matrix4 Hmd::orthoSubProjectionMatrix(const unsigned int eye, const Matrix4& proj, const Vector2& scale, Float distance) const {
     ovrMatrix4f sub = ovrMatrix4f_OrthoSubProjection(ovrMatrix4f(proj), ovrVector2f(scale), distance,
                                                       _hmdToEyeViewOffset[eye].x);
     return Matrix4(sub);

--- a/src/Magnum/LibOvrIntegration/Hmd.cpp
+++ b/src/Magnum/LibOvrIntegration/Hmd.cpp
@@ -140,7 +140,10 @@ std::unique_ptr<SwapTextureSet> Hmd::createSwapTextureSet(TextureFormat format, 
 }
 
 Hmd& Hmd::pollEyePoses() {
-    ovrHmd_GetEyePoses(_hmd, 0, _hmdToEyeViewOffset, _ovrPoses, &_trackingState);
+    _frameTiming = ovrHmd_GetFrameTiming(_hmd, _frameIndex);
+    _trackingState = ovrHmd_GetTrackingState(_hmd, _frameTiming.DisplayMidpointSeconds);
+    ovr_CalcEyePoses(_trackingState.HeadPose.ThePose, _hmdToEyeViewOffset, _ovrPoses);
+
     return *this;
 }
 

--- a/src/Magnum/LibOvrIntegration/Hmd.cpp
+++ b/src/Magnum/LibOvrIntegration/Hmd.cpp
@@ -1,0 +1,158 @@
+/*
+    This file is part of Magnum.
+
+    Copyright © 2010, 2011, 2012, 2013, 2014, 2015
+              Vladimír Vondruš <mosra@centrum.cz>
+    Copyright © 2015
+              Jonathan Hale <squareys@googlemail.com>
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included
+    in all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+
+#include "Magnum/LibOVRIntegration/Hmd.h"
+
+#include "Magnum/LibOVRIntegration/HmdEnum.h"
+#include "Magnum/LibOVRIntegration/Conversion.h"
+
+#include <Magnum/TextureFormat.h>
+
+#include <OVR_CAPI_GL.h>
+
+namespace Magnum { namespace LibOvrIntegration {
+
+SwapTextureSet::SwapTextureSet(const Hmd& hmd, TextureFormat format, Vector2i size) : _hmd(hmd), _format(format), _size(size) {
+    ovrHmd_CreateSwapTextureSetGL(_hmd._hmd, Containers::EnumSet<TextureFormat>::UnderlyingType(_format), _size.x(), _size.y(), &_swapTextureSet);
+
+    /* wrap the texture set for magnum */
+    _textures = new Texture2D*[_swapTextureSet->TextureCount];
+
+    for(int i = 0; i < _swapTextureSet->TextureCount; ++i) {
+        _textures[i] = new Texture2D(wrap(_swapTextureSet->Textures[i]));
+        _textures[i]->setMinificationFilter(Sampler::Filter::Linear)
+                    .setMagnificationFilter(Sampler::Filter::Linear)
+                    .setWrapping(Sampler::Wrapping::ClampToEdge);
+    }
+}
+
+SwapTextureSet::~SwapTextureSet() {
+    int numTextures = _swapTextureSet->TextureCount;
+
+    ovrHmd_DestroySwapTextureSet(_hmd._hmd, _swapTextureSet);
+
+    for(int i = 0; i < numTextures; ++i) {
+        delete _textures[i];
+    }
+    delete _textures;
+}
+
+Texture2D& SwapTextureSet::getActiveTexture() const {
+    return *_textures[_swapTextureSet->CurrentIndex];
+}
+
+//----------------------------------------------------------------
+
+Hmd::Hmd(ovrHmd hmd, HmdStatusFlags flags) : _hmd(hmd), _flags(flags) {
+}
+
+Hmd::~Hmd() {
+    if(_flags & HmdStatusFlag::HasMirrorTexture) {
+        ovrHmd_DestroyMirrorTexture(_hmd, _ovrMirrorTexture);
+        _mirrorTexture.reset();
+    }
+
+    ovrHmd_Destroy(_hmd);
+}
+
+Hmd& Hmd::setEnabledCaps(HmdCapabilities caps){
+    ovrHmd_SetEnabledCaps(_hmd, HmdCapabilities::UnderlyingType(caps));
+    return *this;
+}
+
+Hmd& Hmd::configureTracking(HmdTrackingCapabilities caps, HmdTrackingCapabilities required) {
+    ovrHmd_ConfigureTracking(_hmd,
+           HmdTrackingCapabilities::UnderlyingType(caps),
+           HmdTrackingCapabilities::UnderlyingType(required));
+    return *this;
+}
+
+Hmd& Hmd::configureRendering() {
+    /* get offset from center to left/right eye. The offset lengths may differ. */
+    _hmdToEyeViewOffset[0] = ovrHmd_GetRenderDesc(_hmd, ovrEye_Left, _hmd->DefaultEyeFov[0]).HmdToEyeViewOffset;
+    _hmdToEyeViewOffset[1] = ovrHmd_GetRenderDesc(_hmd, ovrEye_Right, _hmd->DefaultEyeFov[1]).HmdToEyeViewOffset;
+
+    _viewScale.HmdSpaceToWorldScaleInMeters = 1.0f;
+    _viewScale.HmdToEyeViewOffset[0] = _hmdToEyeViewOffset[0];
+    _viewScale.HmdToEyeViewOffset[1] = _hmdToEyeViewOffset[1];
+
+    return *this;
+}
+
+Vector2i Hmd::getFovTextureSize(const unsigned int eye) {
+    return Vector2i(ovrHmd_GetFovTextureSize(_hmd, ovrEyeType(eye), _hmd->DefaultEyeFov[eye], 1.0));
+}
+
+Texture2D& Hmd::createMirrorTexture(TextureFormat format, Vector2i size) {
+    CORRADE_ASSERT(!(_flags & HmdStatusFlag::HasMirrorTexture),
+           "Hmd::createMirrorTexture may only be called once, returning result of previous call.",
+            *_mirrorTexture);
+
+    ovrResult result = ovrHmd_CreateMirrorTextureGL(
+                _hmd,
+                Containers::EnumSet<TextureFormat>::UnderlyingType(format),
+                size.x(),
+                size.y(),
+                &_ovrMirrorTexture);
+
+    if(result != ovrSuccess) {
+        ovrErrorInfo info;
+        ovr_GetLastErrorInfo(&info);
+        Error() << info.ErrorString;
+    }
+
+    _mirrorTexture.reset(new Texture2D(wrap(*_ovrMirrorTexture)));
+
+    return *_mirrorTexture;
+}
+
+std::unique_ptr<SwapTextureSet> Hmd::createSwapTextureSet(TextureFormat format, int eye) {
+    return std::unique_ptr<SwapTextureSet>(new SwapTextureSet(*this, format, getFovTextureSize(eye)));
+}
+
+std::unique_ptr<SwapTextureSet> Hmd::createSwapTextureSet(TextureFormat format, const Vector2i size) {
+    return std::unique_ptr<SwapTextureSet>(new SwapTextureSet(*this, format, size));
+}
+
+Hmd& Hmd::pollEyePoses() {
+    ovrHmd_GetEyePoses(_hmd, 0, _hmdToEyeViewOffset, _ovrPoses, &_trackingState);
+    return *this;
+}
+
+bool Hmd::isDebugHmd() const {
+    return (_flags & HmdStatusFlag::Debug) != HmdStatusFlags{};
+}
+
+std::unique_ptr<DualQuaternion> Hmd::getEyePoses() {
+    DualQuaternion* poses = new DualQuaternion[2]{DualQuaternion(_ovrPoses[0]), DualQuaternion(_ovrPoses[1])};
+
+    return std::unique_ptr<DualQuaternion>(poses);
+}
+
+
+}}

--- a/src/Magnum/LibOvrIntegration/Hmd.cpp
+++ b/src/Magnum/LibOvrIntegration/Hmd.cpp
@@ -34,6 +34,7 @@
 #include <Magnum/TextureFormat.h>
 
 #include <OVR_CAPI_GL.h>
+#include <OVR_CAPI_Util.h>
 
 namespace Magnum { namespace LibOvrIntegration {
 
@@ -137,6 +138,18 @@ std::unique_ptr<SwapTextureSet> Hmd::createSwapTextureSet(TextureFormat format, 
 
 std::unique_ptr<SwapTextureSet> Hmd::createSwapTextureSet(TextureFormat format, const Vector2i size) {
     return std::unique_ptr<SwapTextureSet>(new SwapTextureSet(*this, format, size));
+}
+
+Matrix4 Hmd::projectionMatrix(const unsigned int eye, Float n, Float f) const {
+    ovrMatrix4f proj = ovrMatrix4f_Projection(_hmd->DefaultEyeFov[eye], n, f,
+                                              ovrProjection_RightHanded | ovrProjection_ClipRangeOpenGL);
+    return Matrix4(proj);
+}
+
+Matrix4 Hmd::orthoSubProjectionMatrix(const unsigned int eye, const Matrix4& proj, Vector2 scale, Float distance) const {
+    ovrMatrix4f sub = ovrMatrix4f_OrthoSubProjection(ovrMatrix4f(proj), ovrVector2f(scale), distance,
+                                                      _hmdToEyeViewOffset[eye].x);
+    return Matrix4(sub);
 }
 
 Hmd& Hmd::pollEyePoses() {

--- a/src/Magnum/LibOvrIntegration/Hmd.h
+++ b/src/Magnum/LibOvrIntegration/Hmd.h
@@ -1,0 +1,256 @@
+#ifndef Magnum_LibOvrIntegration_Hmd_h
+#define Magnum_LibOvrIntegration_Hmd_h
+/*
+    This file is part of Magnum.
+
+    Copyright © 2010, 2011, 2012, 2013, 2014, 2015
+              Vladimír Vondruš <mosra@centrum.cz>
+    Copyright © 2015
+              Jonathan Hale <squareys@googlemail.com>
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included
+    in all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+/** @file
+ * @brief Class @ref Magnum::LibOvrIntegration::Hmd and class @ref Magnum::LibOvrIntegration::SwapTextureSet.
+ */
+
+#include <memory>
+#include <OVR_CAPI.h>
+#include <Magnum/Texture.h>
+#include <Magnum/Magnum.h>
+
+#include "Magnum/LibOVRIntegration/visibility.h"
+#include "Magnum/LibOVRIntegration/Conversion.h"
+#include "Magnum/LibOVRIntegration/LibOvrIntegration.h"
+
+namespace Magnum { namespace LibOvrIntegration {
+
+/**
+@brief SwapTextureSet
+
+Contains an array of texture which can be rendered to an hmd display by the
+libOVR compositor after applying distortion to it.
+
+@todoc
+
+@see @ref Hmd
+*/
+class MAGNUM_LIBOVRINTEGRATION_EXPORT SwapTextureSet {
+    public:
+        /**
+         * @brief Constructor.
+         * @param hmd Hmd for which this SwapTextureSet is created.
+         * @param format Texture format.
+         * @param size Size for the textures.
+         */
+        explicit SwapTextureSet(const Hmd& hmd, TextureFormat format, Vector2i size);
+        ~SwapTextureSet();
+
+        /** @brief Currently active texture in the set. */
+        Texture2D& getActiveTexture() const;
+
+        /**
+         * @brief Increment to use the next texture in the set.
+         * @return Reference to self (for method chaining)
+         */
+        SwapTextureSet& increment() {
+            _swapTextureSet->CurrentIndex = (_swapTextureSet->CurrentIndex + 1) % _swapTextureSet->TextureCount;
+            return *this;
+        }
+
+        /** @brief The underlying ovrSwapTextureSet. */
+        ovrSwapTextureSet& getOvrSwapTextureSet() {
+            return *_swapTextureSet;
+        }
+
+    private:
+        const Hmd& _hmd;
+        TextureFormat _format;
+        Vector2i _size;
+
+        ovrSwapTextureSet* _swapTextureSet;
+        Texture2D** _textures;
+};
+
+/**
+@brief Hmd
+
+Wraps ovrHmd_* methods.
+
+## Usage
+
+Instances of Hmd are created by @ref LibOvrContext.
+
+@code
+std::unique_ptr<Hmd> hmd = LibOvrContext::get().initialize().createHmd(0, HmdType::DK2);
+hmd->setEnabledCaps({HmdCapability::LowPersistence, HmdCapability::DynamicPrediction});
+hmd->configureTracking({HmdTrackingCapability::Orientation,
+                        HmdTrackingCapability::MagYawCorrection,
+                        HmdTrackingCapability::Position}, {});
+// ...
+LibOvrContext::get().shutdown();
+@endcode
+
+@todoc hmdpose, mirror texture, swaptextureset
+*/
+class MAGNUM_LIBOVRINTEGRATION_EXPORT Hmd {
+    public:
+
+        /** @brief Destructor. */
+        ~Hmd();
+
+        /**
+         * @brief Enable or disable hmd capabilities
+         * @param caps @ref HmdCapability flags to enable.
+         * @return Reference to self (for method chaining)
+         */
+        Hmd& setEnabledCaps(HmdCapabilities caps);
+
+        /**
+         * @brief Enable or disable hmd tracking capabilities
+         * @param caps @ref HmdTrackingCapability flags to enable.
+         * @return Reference to self (for method chaining)
+         */
+        Hmd& configureTracking(HmdTrackingCapabilities caps, HmdTrackingCapabilities required);
+
+        /**
+         * @brief Configure rendering to the rift.
+         *
+         * Includes setting up hmd to eye offsets internally.
+         *
+         * @return Reference to self (for method chaining)
+         */
+        Hmd& configureRendering();
+
+        /**
+         * @brief Get preferred size for textures used for rendering to this hmd.
+         * @param eye Eye index to get the texture size for.
+         * @return Size for textures.
+         */
+        Vector2i getFovTextureSize(const unsigned int eye);
+
+        /**
+         * @brief Create a mirror texture.
+         *
+         * The libOVR compositor will render a copy of its result to the texture returned
+         * by this method.
+         *
+         * @param format Texture format.
+         * @param size Size for the mirror texture.
+         * @return Pointer to the created mirror texture. Its destruction is handled by the Hmd.
+         */
+        Texture2D& createMirrorTexture(TextureFormat format, Vector2i size);
+
+        /**
+         * @brief Convenience method to create a @ref SwapTextureSet for this Hmd.
+         * @param format Texture format.
+         * @param eye Eye index which will be used to get the preferred size for the texture.
+         * @return The created @ref SwapTextureSet.
+         *
+         * @see createSwapTextureSet(format,eye)
+         */
+        std::unique_ptr<SwapTextureSet> createSwapTextureSet(TextureFormat format, int eye);
+
+        /**
+         * @brief Create a @ref SwapTextureSet for this Hmd.
+         * @param format Texture format.
+         * @param size Size for the textures in the created @ref SwapTextureSet.
+         * @return The created @ref SwapTextureSet.
+         *
+         * @see createSwapTextureSet(format,eye)
+         */
+        std::unique_ptr<SwapTextureSet> createSwapTextureSet(TextureFormat format, const Vector2i size);
+
+        /**
+         * @brief getEyePoses Get the current translation for the eyes from the
+         *                    head pose tracked by the hmd.
+         * @return A @ref std::unique_ptr to an array of Matrix4 with size 2,
+         *         the transformations for each eye.
+         */
+        std::unique_ptr<DualQuaternion> getEyePoses();
+
+        /**
+         * @brief Refresh cached eye poses.
+         * @see Use @ref getEyePoses() to access the result.
+         * @return Reference to self (for method chaining)
+         */
+        Hmd& pollEyePoses();
+
+        /** @brief Resolution of the Hmd's display. */
+        Vector2i resolution() const {
+            return Vector2i(_hmd->Resolution);
+        }
+
+        /**
+         * @brief Tan of the fov for an eye.
+         * @param eye Eye index.
+         * @return Vector of eye fovs, x being horizontal and y vertical.
+         */
+        Vector2 defaultEyeFov(int eye) const {
+            const ovrFovPort fov = _hmd->DefaultEyeFov[eye];
+            return {fov.RightTan + fov.LeftTan, fov.UpTan + fov.DownTan};
+        }
+
+        /** @brief Get the underlying ovrHmd. */
+        ovrHmd getOvrHmd() const {
+            return _hmd;
+        }
+
+        /** @brief Get the ovrViewScale. */
+        const ovrViewScaleDesc& getOvrViewScale() const {
+            return _viewScale;
+        }
+
+        /** @brief Whether this hmd is a debug hmd (true) or connection to a real device (false). */
+        bool isDebugHmd() const;
+
+        /**
+         * @brief Get a pointer to the most current eye poses as ovrPosef.
+         * @return A pointer to an ovrPosef[2] containing the most
+         *         recently polled eye poses.
+         * @see Hmd::pollEyePoses()
+         */
+        const ovrPosef* getOvrEyePoses() const {
+            return _ovrPoses;
+        }
+
+    private:
+        explicit Hmd(ovrHmd hmd, HmdStatusFlags flags);
+
+        ovrHmd _hmd;
+        ovrPosef _ovrPoses[2];
+        ovrVector3f _hmdToEyeViewOffset[2];
+        ovrViewScaleDesc _viewScale;
+
+        ovrTrackingState _trackingState;
+
+        ovrTexture* _ovrMirrorTexture;
+        std::unique_ptr<Texture2D> _mirrorTexture;
+
+        HmdStatusFlags _flags;
+
+        friend class SwapTextureSet;
+        friend class LibOvrContext;
+        friend class LayerEyeFov;
+};
+
+}}
+
+#endif

--- a/src/Magnum/LibOvrIntegration/Hmd.h
+++ b/src/Magnum/LibOvrIntegration/Hmd.h
@@ -219,7 +219,7 @@ class MAGNUM_LIBOVRINTEGRATION_EXPORT Hmd {
          * @param eye Eye index to get the texture size for.
          * @return Size for textures.
          */
-        Vector2i getFovTextureSize(const unsigned int eye);
+        Vector2i getFovTextureSize(unsigned int eye);
 
         /**
          * @brief Create a mirror texture.
@@ -231,7 +231,7 @@ class MAGNUM_LIBOVRINTEGRATION_EXPORT Hmd {
          * @param size Size for the mirror texture.
          * @return Pointer to the created mirror texture. Its destruction is handled by the Hmd.
          */
-        Texture2D& createMirrorTexture(TextureFormat format, Vector2i size);
+        Texture2D& createMirrorTexture(TextureFormat format, const Vector2i& size);
 
         /**
          * @brief Convenience method to create a @ref SwapTextureSet for this Hmd.
@@ -251,7 +251,7 @@ class MAGNUM_LIBOVRINTEGRATION_EXPORT Hmd {
          *
          * @see createSwapTextureSet(format,eye)
          */
-        std::unique_ptr<SwapTextureSet> createSwapTextureSet(TextureFormat format, const Vector2i size);
+        std::unique_ptr<SwapTextureSet> createSwapTextureSet(TextureFormat format, const Vector2i& size);
 
         /**
          * @brief getEyePoses Get the current translation for the eyes from the
@@ -279,7 +279,7 @@ class MAGNUM_LIBOVRINTEGRATION_EXPORT Hmd {
          * @return Vector of eye fovs, x being horizontal and y vertical.
          */
         Vector2 defaultEyeFov(const int eye) const {
-            const ovrFovPort fov = _hmd->DefaultEyeFov[eye];
+            const ovrFovPort& fov = _hmd->DefaultEyeFov[eye];
             return {fov.RightTan + fov.LeftTan, fov.UpTan + fov.DownTan};
         }
 
@@ -296,7 +296,7 @@ class MAGNUM_LIBOVRINTEGRATION_EXPORT Hmd {
          *
          * @ref Hmd::orthoSubProjectionMatrix().
          */
-        Matrix4 projectionMatrix(const unsigned int eye, Float n, Float f) const;
+        Matrix4 projectionMatrix(unsigned int eye, Float n, Float f) const;
 
         /**
          * @brief Get a projection matrix for projection to an orthogonal plane.
@@ -312,7 +312,7 @@ class MAGNUM_LIBOVRINTEGRATION_EXPORT Hmd {
          *
          * @ref Hmd::projectionMatrix().
          */
-        Matrix4 orthoSubProjectionMatrix(const unsigned int eye, const Matrix4& proj, Vector2 scale, Float distance) const;
+        Matrix4 orthoSubProjectionMatrix(unsigned int eye, const Matrix4& proj, const Vector2& scale, Float distance) const;
 
         /** @brief Get the underlying ovrHmd. */
         ovrHmd getOvrHmd() const {

--- a/src/Magnum/LibOvrIntegration/Hmd.h
+++ b/src/Magnum/LibOvrIntegration/Hmd.h
@@ -314,6 +314,19 @@ class MAGNUM_LIBOVRINTEGRATION_EXPORT Hmd {
             return _ovrPoses;
         }
 
+        /** @brief Get the current frame index. */
+        UnsignedInt getCurrentFrameIndex() const {
+            return _frameIndex;
+        }
+
+        /**
+         * @brief Increment the frame index. This method is called by @ref Compositor::submitFrame().
+         * @return The new index value.
+         */
+        UnsignedInt incFrameIndex() {
+            return ++_frameIndex;
+        }
+
     private:
         explicit Hmd(ovrHmd hmd, HmdStatusFlags flags);
 
@@ -322,7 +335,10 @@ class MAGNUM_LIBOVRINTEGRATION_EXPORT Hmd {
         ovrVector3f _hmdToEyeViewOffset[2];
         ovrViewScaleDesc _viewScale;
 
+        ovrFrameTiming _frameTiming;
         ovrTrackingState _trackingState;
+
+        UnsignedInt _frameIndex;
 
         ovrTexture* _ovrMirrorTexture;
         std::unique_ptr<Texture2D> _mirrorTexture;

--- a/src/Magnum/LibOvrIntegration/Hmd.h
+++ b/src/Magnum/LibOvrIntegration/Hmd.h
@@ -76,7 +76,7 @@ class MAGNUM_LIBOVRINTEGRATION_EXPORT SwapTextureSet {
         }
 
         /** @brief The underlying ovrSwapTextureSet. */
-        ovrSwapTextureSet& getOvrSwapTextureSet() {
+        ovrSwapTextureSet& getOvrSwapTextureSet() const {
             return *_swapTextureSet;
         }
 
@@ -248,7 +248,6 @@ class MAGNUM_LIBOVRINTEGRATION_EXPORT Hmd {
 
         friend class SwapTextureSet;
         friend class LibOvrContext;
-        friend class LayerEyeFov;
 };
 
 }}

--- a/src/Magnum/LibOvrIntegration/Hmd.h
+++ b/src/Magnum/LibOvrIntegration/Hmd.h
@@ -275,21 +275,44 @@ class MAGNUM_LIBOVRINTEGRATION_EXPORT Hmd {
 
         /**
          * @brief Tan of the fov for an eye.
-         *
-         * Can be used to create a perspective projection matrix for a camera:
-         * @code
-         * const Float near = 0.001f;
-         * const Float far = 100.0f;
-         * camera.setPerspective(_hmd.defaultEyeFov(eye) * near, near, far);
-         * @endcode
-         *
          * @param eye Eye index.
          * @return Vector of eye fovs, x being horizontal and y vertical.
          */
-        Vector2 defaultEyeFov(int eye) const {
+        Vector2 defaultEyeFov(const int eye) const {
             const ovrFovPort fov = _hmd->DefaultEyeFov[eye];
             return {fov.RightTan + fov.LeftTan, fov.UpTan + fov.DownTan};
         }
+
+        /**
+         * @brief Get the projection matrix.
+         *
+         * Get the projection matrix for an eye index for which should be used for
+         * prespective rendering to this hmd.
+         *
+         * @param eye The eye index.
+         * @param near Distance to near frustrum plane.
+         * @param far Distance to far frustrum plane.
+         * @return The projection matrix for eye.
+         *
+         * @ref Hmd::orthoSubProjectionMatrix().
+         */
+        Matrix4 projectionMatrix(const unsigned int eye, Float n, Float f) const;
+
+        /**
+         * @brief Get a projection matrix for projection to an orthogonal plane.
+         *
+         * Get a projection matrix which can be used for projection onto a 2D plane orthogonal
+         * to the hmds view/screen with distance from hmds position.
+         *
+         * @param eye The eye index.
+         * @param proj Projection matrix. Usually created by @ref Hmd::projectionMatrix().
+         * @param scale Scale for the 2D plane.
+         * @param distance Distance of the plane from hmd position.
+         * @return The projection matrix for eye.
+         *
+         * @ref Hmd::projectionMatrix().
+         */
+        Matrix4 orthoSubProjectionMatrix(const unsigned int eye, const Matrix4& proj, Vector2 scale, Float distance) const;
 
         /** @brief Get the underlying ovrHmd. */
         ovrHmd getOvrHmd() const {

--- a/src/Magnum/LibOvrIntegration/HmdEnum.h
+++ b/src/Magnum/LibOvrIntegration/HmdEnum.h
@@ -1,0 +1,114 @@
+#ifndef Magnum_LibOvrIntegration_HmdEnum_h
+#define Magnum_LibOvrIntegration_HmdEnum_h
+/*
+    This file is part of Magnum.
+
+    Copyright © 2010, 2011, 2012, 2013, 2014, 2015
+              Vladimír Vondruš <mosra@centrum.cz>
+    Copyright © 2015
+              Jonathan Hale <squareys@googlemail.com>
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included
+    in all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+/** @file
+ * @brief Wrapped libOVR enums HmdType, HmdCapability, HmdTrackingCapability and HmdStatusFlag.
+ *
+ * @author Jonathan Hale (Squareys)
+ */
+
+#include <memory>
+
+#include <Magnum/Texture.h>
+#include <Magnum/Magnum.h>
+
+#include <OVR_CAPI.h>
+
+#include "Magnum/LibOvrIntegration/visibility.h"
+
+
+namespace Magnum { namespace LibOvrIntegration {
+
+enum class HmdType: UnsignedByte {
+    None = ovrHmd_None, /**< Absence of an hmd type. */
+    DK1 = ovrHmd_DK1, /**< Developer Kit 1. */
+    DKHD = ovrHmd_DKHD, /**< HD prototype, aka Crystal Cove. */
+    DK2 = ovrHmd_DK2, /**< Developer Kit 2. */
+    BlackStar = ovrHmd_BlackStar, /**< Black Star Prototype. */
+    CB = ovrHmd_CB, /**< Crescent Bay prototype. */
+    Other = ovrHmd_Other /**< Unknown type. */
+};
+
+enum class HmdCapability: UnsignedInt {
+    /**
+     *  @brief Toggles low persistence mode on or off.
+     *  @details This setting reduces eye-tracking based motion blur. Eye-tracking based motion blur is caused by the viewer's focal point
+     *  moving more pixels than have refreshed in the same period of time.\n
+     *  The disadvantage of this setting is that this reduces the average brightness of the display and causes some users to perceive flicker.\n
+     *  <I>There is no performance cost for this option. Oculus recommends exposing it to the user as an optional setting.</I> */
+    LowPersistence = ovrHmdCap_LowPersistence,
+
+    /** @brief Adjusts prediction dynamically based on internally measured latency. */
+    DynamicPrediction = ovrHmdCap_DynamicPrediction,
+
+    /** @brief Supports rendering without VSync for debugging. */
+    NoVSync = ovrHmdCap_NoVSync
+};
+
+/**
+@brief Hmd capabilities flags
+*/
+typedef Containers::EnumSet<HmdCapability> HmdCapabilities;
+CORRADE_ENUMSET_OPERATORS(HmdCapabilities)
+
+enum class HmdTrackingCapability: UnsignedInt {
+    /** @brief Supports orientation tracking (IMU). */
+    Orientation = ovrTrackingCap_Orientation,
+
+    /** @brief Supports yaw drift correction via a magnetometer or other means. */
+    MagYawCorrection = ovrTrackingCap_MagYawCorrection,
+
+    /** @brief Supports positional tracking. */
+    Position = ovrTrackingCap_Position,
+};
+
+/**
+@brief Hmd tracking capabilities flags
+*/
+typedef Containers::EnumSet<HmdTrackingCapability> HmdTrackingCapabilities;
+CORRADE_ENUMSET_OPERATORS(HmdTrackingCapabilities)
+
+enum class HmdStatusFlag: UnsignedByte {
+    /** A mirror texture was created for the hmd and needs to
+     * be destoryed on destruction of the hmd.  */
+    HasMirrorTexture = 1 << 0,
+
+    /** The hmd was created as a debug hmd (without real hardware). */
+    Debug = 1 << 1
+};
+
+/**
+@brief Hmd tracking capabilities flags
+*/
+typedef Containers::EnumSet<HmdStatusFlag> HmdStatusFlags;
+CORRADE_ENUMSET_OPERATORS(HmdStatusFlags)
+
+}}
+
+#endif

--- a/src/Magnum/LibOvrIntegration/LibOvrIntegration.h
+++ b/src/Magnum/LibOvrIntegration/LibOvrIntegration.h
@@ -1,0 +1,63 @@
+#ifndef Magnum_LibOvrIntegration_LibOvrIntegration_h
+#define Magnum_LibOvrIntegration_LibOvrIntegration_h
+/*
+    This file is part of Magnum.
+
+    Copyright © 2010, 2011, 2012, 2013, 2014, 2015
+              Vladimír Vondruš <mosra@centrum.cz>
+    Copyright © 2015
+              Jonathan Hale <squareys@googlemail.com>
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included
+    in all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+/** @file
+ * @brief Forward declarations for the Magnum::LibOvrIntegration namespace.
+ *
+ * @author Jonathan Hale (Squareys)
+ */
+
+#include <Magnum/Magnum.h>
+
+namespace Magnum { namespace LibOvrIntegration {
+
+class Hmd;
+class SwapTextureSet;
+class LibOvrContext;
+class Compositor;
+class Layer;
+class LayerDirect;
+class LayerEyeFov;
+class LayerEyeFovDepth;
+class LayerQuad;
+class TimewarpProjectionDescription;
+
+enum class HmdType: UnsignedByte;
+enum class HmdCapability: UnsignedInt;
+enum class HmdTrackingCapability: UnsignedInt;
+enum class HmdStatusFlag: UnsignedByte;
+enum class LayerType: UnsignedByte;
+
+typedef Containers::EnumSet<HmdCapability> HmdCapabilities;
+typedef Containers::EnumSet<HmdTrackingCapability> HmdTrackingCapabilities;
+typedef Containers::EnumSet<HmdStatusFlag> HmdStatusFlags;
+
+}}
+
+#endif

--- a/src/Magnum/LibOvrIntegration/Test/CMakeLists.txt
+++ b/src/Magnum/LibOvrIntegration/Test/CMakeLists.txt
@@ -3,6 +3,8 @@
 #
 #   Copyright © 2010, 2011, 2012, 2013, 2014, 2015
 #             Vladimír Vondruš <mosra@centrum.cz>
+#   Copyright © 2015
+#             Jonathan Hale <squareys@googlemail.com>
 #
 #   Permission is hereby granted, free of charge, to any person obtaining a
 #   copy of this software and associated documentation files (the "Software"),
@@ -23,10 +25,4 @@
 #   DEALINGS IN THE SOFTWARE.
 #
 
-if(WITH_BULLET)
-    add_subdirectory(BulletIntegration)
-endif()
-
-if(WITH_OVR)
-    add_subdirectory(LibOvrIntegration)
-endif()
+corrade_add_test(LibOvrConversionTest ConversionTest.cpp LIBRARIES ${MAGNUM_LIBRARY})

--- a/src/Magnum/LibOvrIntegration/visibility.h
+++ b/src/Magnum/LibOvrIntegration/visibility.h
@@ -1,0 +1,39 @@
+#ifndef Magnum_LibOvrIntegration_visibility_h
+#define Magnum_LibOvrIntegration_visibility_h
+/*
+    This file is part of Magnum.
+
+    Copyright © 2010, 2011, 2012, 2013, 2014, 2015
+              Vladimír Vondruš <mosra@centrum.cz>
+    Copyright © 2015
+              Jonathan Hale <squareys@googlemail.com>
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included
+    in all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+#include <Corrade/Utility/VisibilityMacros.h>
+
+#ifdef MagnumLibOvrIntegration_EXPORTS
+    #define MAGNUM_LIBOVRINTEGRATION_EXPORT CORRADE_VISIBILITY_EXPORT
+#else
+    #define MAGNUM_LIBOVRINTEGRATION_EXPORT CORRADE_VISIBILITY_IMPORT
+#endif
+#define MAGNUM_LibOvrIntegration_LOCAL CORRADE_VISIBILITY_LOCAL
+
+#endif


### PR DESCRIPTION
Hi @mosra, Hi everybody,

Since this definitely will be a thing now, let's move discussion of LibOVRIntegration to here. Previous discussion can be found in https://github.com/mosra/magnum-examples/pull/10.

If you are okay with it, only the most important compositing layer (ovrLayerEyeFov) will be wrapped for now and I will create an issue which lists the missing wrappers and implement them when needed.

Current TODOs:
- [x] Finish wrapping compositor.
- [x] Cleanup code.
  - [x] Cleanup code formatting. 
  - [x] Change `// comments` to `/* comments */`.
  - [x] Change `MagnumLibOvrIntegration_EXPORTS` to be all uppercase.
  - [x] Remove `#endif` description comments.
  - [x] Add copyrights properly.
  - [x] Fix posef test.
  - [x] Use `#include<memory>`.
  - [x] Add enumset operators.
  - [x] Fix `ovrSwapTextureSet* getOvrSwapTextureSet()` being a raw pointer.
  - [x] Change case of `MAGNUM_LibOvrIntegration_EXPORT`.
  - [x] Refactor context.
  - [x] Use absolute includes.
- [x] Rebase to cleanup commit history.
   - [x] Squash fixups.
- [x] Finish doc++.
- [x] Finish `FindOVR.cmake`.