### PR TITLE
Fix for handling of Bullet optimized vs debug libraries in FindMagnumPlugins.cmake

### DIFF
--- a/modules/FindMagnumIntegration.cmake
+++ b/modules/FindMagnumIntegration.cmake
@@ -160,8 +160,18 @@ foreach(_component ${MagnumIntegration_FIND_COMPONENTS})
             find_package(Bullet)
             set_property(TARGET MagnumIntegration::${_component} APPEND PROPERTY
                 INTERFACE_INCLUDE_DIRECTORIES ${BULLET_INCLUDE_DIRS})
-            set_property(TARGET MagnumIntegration::${_component} APPEND PROPERTY
-                INTERFACE_LINK_LIBRARIES ${BULLET_LIBRARIES})
+            # Need to handle special cases where both debug and release
+            # libraries are available (in form of debug;A;optimized;B in
+            # BULLET_LIBRARIES), thus appending them one by one
+            foreach(lib BULLET_DYNAMICS_LIBRARY BULLET_COLLISION_LIBRARY BULLET_MATH_LIBRARY BULLET_SOFTBODY_LIBRARY)
+                if(${lib}_DEBUG)
+                    set_property(TARGET MagnumIntegration::${_component} APPEND PROPERTY
+                        INTERFACE_LINK_LIBRARIES "$<$<NOT:$<CONFIG:Debug>>:${${lib}}>;$<$<CONFIG:Debug>:${${lib}_DEBUG}>")
+                else()
+                    set_property(TARGET MagnumIntegration::${_component} APPEND PROPERTY
+                        INTERFACE_LINK_LIBRARIES ${${lib}})
+                endif()
+            endforeach()
 
             set(_MAGNUMINTEGRATION_${_COMPONENT}_INCLUDE_PATH_NAMES MotionState.h)
 


### PR DESCRIPTION
Hi @mosra !

Here's a small fix for how optimized/debug bullet libraries are handled in FindMagnumPlugins.

From the commit message: 

> When both debug and release builds of bullet libraries are found,
`${BULLET_LIBRARIES}` contains "optimized" and "debug" keywords which are
not handles by `set_property`. Using `target_link_libraries` instead lets
the find module appropriately choose whether to use the debug or optimized
libraries.

Regards, Jonathan.