### PR TITLE
OvrIntegration: Hotfix for Runtime not able to create TextureSwapChains

### DIFF
--- a/src/Magnum/OvrIntegration/Session.cpp
+++ b/src/Magnum/OvrIntegration/Session.cpp
@@ -60,6 +60,7 @@ TextureSwapChain::TextureSwapChain(const Session& session, const Vector2i& size)
     desc.SampleCount = 1;
     desc.StaticImage = ovrFalse;
     desc.MiscFlags = ovrTextureMisc_None;
+    desc.BindFlags = ovrTextureBind_None;
 
     ovrResult result = ovr_CreateTextureSwapChainGL(_session.ovrSession(), &desc, &_textureSwapChain);
 


### PR DESCRIPTION
Hi @mosra !

Just runtime tested the Oculus integration... I guess I should have ealier. So here is a tiny amendment to the recent cleanup.

> Although the Oculus SDK doc notes "is not used", the Runtime errors out
when BindFlags is set to anything else than ovrTextureBind_None on GL apps.
(In this case uninitialized memory.)

Regards, Squareys.