### PR TITLE
Fix MotionState

### DIFF
--- a/src/Magnum/BulletIntegration/DebugDraw.h
+++ b/src/Magnum/BulletIntegration/DebugDraw.h
@@ -32,6 +32,7 @@
 
 #include <vector>
 #include <Corrade/Containers/ArrayView.h>
+#include <Corrade/Utility/Macros.h>
 #include <Magnum/Buffer.h>
 #include <Magnum/DebugOutput.h>
 #include <Magnum/Magnum.h>

--- a/src/Magnum/BulletIntegration/Integration.h
+++ b/src/Magnum/BulletIntegration/Integration.h
@@ -33,6 +33,7 @@
 #include <LinearMath/btMatrix3x3.h>
 #include <LinearMath/btTransform.h>
 #include <Magnum/Math/RectangularMatrix.h>
+#include <Magnum/Math/Quaternion.h>
 
 #include "Magnum/BulletIntegration/visibility.h"
 
@@ -73,6 +74,16 @@ template<> struct RectangularMatrixConverter<4, 4, btScalar, btTransform> {
         btTransform transform;
         transform.setFromOpenGLMatrix(other.data());
         return transform;
+    }
+};
+
+template<> struct QuaternionConverter<btScalar, btQuaternion> {
+    static Quaternion<Float> from(const btQuaternion& other) {
+        return {{other.x(), other.y(), other.z()}, other.w()};
+    }
+
+    static btQuaternion to(const Quaternion<Float>& other) {
+        return {other.vector().x(), other.vector().y(), other.vector().z(), other.scalar()};
     }
 };
 

--- a/src/Magnum/BulletIntegration/Integration.h
+++ b/src/Magnum/BulletIntegration/Integration.h
@@ -31,6 +31,7 @@
  */
 
 #include <LinearMath/btMatrix3x3.h>
+#include <LinearMath/btTransform.h>
 #include <Magnum/Math/RectangularMatrix.h>
 
 #include "Magnum/BulletIntegration/visibility.h"
@@ -58,6 +59,20 @@ template<> struct RectangularMatrixConverter<3, 3, btScalar, btMatrix3x3> {
         return {other[0][0], other[0][1], other[0][2],
                 other[1][0], other[1][1], other[1][2],
                 other[2][0], other[2][1], other[2][2]};
+    }
+};
+
+template<> struct RectangularMatrixConverter<4, 4, btScalar, btTransform> {
+    static RectangularMatrix<4, 4, Float> from(const btTransform& other) {
+        RectangularMatrix<4, 4, Float> mat;
+        other.getOpenGLMatrix(mat.data());
+        return mat;
+    }
+
+    static btTransform to(const RectangularMatrix<4, 4, Float>& other) {
+        btTransform transform;
+        transform.setFromOpenGLMatrix(other.data());
+        return transform;
     }
 };
 

--- a/src/Magnum/BulletIntegration/MotionState.h
+++ b/src/Magnum/BulletIntegration/MotionState.h
@@ -31,7 +31,7 @@
  */
 
 #include <LinearMath/btMotionState.h>
-#include <Magnum/SceneGraph/Object.h>
+#include <Magnum/SceneGraph/AbstractFeature.h>
 #include <Magnum/SceneGraph/AbstractTranslationRotation3D.h>
 
 #include "Magnum/BulletIntegration/visibility.h"

--- a/src/Magnum/BulletIntegration/MotionState.h
+++ b/src/Magnum/BulletIntegration/MotionState.h
@@ -43,7 +43,31 @@ namespace Magnum { namespace BulletIntegration {
 
 Encapsulates `btMotionState` as @ref SceneGraph feature.
 
-@todoc Usage...
+# Usage
+
+Common usage is to either create a `btRigidBody` to share transformation with
+a @ref SceneGraph::Object by passing the motion state in its constructor:
+
+@code
+    SceneGraph::Object<SceneGraph::MatrixTransformation3D> object;
+    btRigidBody rigidBody{mass, &(new MotionState{object}).btMotionState(), collisionShape};
+
+    // rigidBody will be affected when changing the transform of object and
+    // object will be affected when transformation of rigidBody is changed.
+@endcode
+
+Or setting the motion state afterwards:
+
+@code
+    SceneGraph::Object<SceneGraph::MatrixTransformation3D> object;
+    btRigidBody rigidBody{...};
+    rigidBody.setMotionState(&(new MotionState{object}).btMotionState());
+@endcode
+
+Note that changes to a rigidBody using `btRigidBody::setWorldTransform()` may
+only update the motion state of non-static objects and while
+`btDynamicsWorld::stepSimulation()` is called.
+
 */
 class MAGNUM_BULLETINTEGRATION_EXPORT MotionState: public SceneGraph::AbstractBasicFeature3D<btScalar>, private btMotionState {
     public:

--- a/src/Magnum/BulletIntegration/MotionState.h
+++ b/src/Magnum/BulletIntegration/MotionState.h
@@ -69,7 +69,7 @@ only update the motion state of non-static objects and while
 `btDynamicsWorld::stepSimulation()` is called.
 
 */
-class MAGNUM_BULLETINTEGRATION_EXPORT MotionState: public SceneGraph::AbstractBasicFeature3D<btScalar>, private btMotionState {
+class MotionState: public SceneGraph::AbstractBasicFeature3D<btScalar>, private btMotionState {
     public:
         /**
          * @brief Constructor
@@ -77,17 +77,19 @@ class MAGNUM_BULLETINTEGRATION_EXPORT MotionState: public SceneGraph::AbstractBa
          */
         template<class T> MotionState(T& object);
 
+        ~MotionState() = default;
+
         /** @brief Motion state */
         btMotionState& btMotionState() { return *this; }
 
     private:
-        void MAGNUM_BULLETINTEGRATION_LOCAL getWorldTransform(btTransform& worldTrans) const override;
-        void MAGNUM_BULLETINTEGRATION_LOCAL setWorldTransform(const btTransform& worldTrans) override;
+        void MAGNUM_BULLETINTEGRATION_EXPORT getWorldTransform(btTransform& worldTrans) const override;
+        void MAGNUM_BULLETINTEGRATION_EXPORT setWorldTransform(const btTransform& worldTrans) override;
 
-        SceneGraph::AbstractBasicTranslationRotation3D<btScalar>& transformation;
+        SceneGraph::AbstractBasicTranslationRotation3D<btScalar>& _transformation;
 };
 
-template<class T> MotionState::MotionState(T& object): SceneGraph::AbstractBasicFeature3D<btScalar>(object), transformation(object) {}
+template<class T> MotionState::MotionState(T& object): SceneGraph::AbstractBasicFeature3D<btScalar>(object), _transformation(object) {}
 
 }}
 

--- a/src/Magnum/BulletIntegration/Test/CMakeLists.txt
+++ b/src/Magnum/BulletIntegration/Test/CMakeLists.txt
@@ -4,6 +4,7 @@
 #   Copyright © 2010, 2011, 2012, 2013, 2014, 2015, 2016
 #             Vladimír Vondruš <mosra@centrum.cz>
 #   Copyright © 2013 Jan Dupal <dupal.j@gmail.com>
+#   Copyright © 2016 Jonathan Hale <squareys@googlemail.com>
 #
 #   Permission is hereby granted, free of charge, to any person obtaining a
 #   copy of this software and associated documentation files (the "Software"),
@@ -24,5 +25,5 @@
 #   DEALINGS IN THE SOFTWARE.
 #
 
-corrade_add_test(BulletIntegrationTest IntegrationTest.cpp LIBRARIES MagnumBulletIntegration)
+corrade_add_test(BulletIntegrationTest IntegrationTest.cpp LIBRARIES MagnumBulletIntegration ${BULLET_LIBRARIES})
 corrade_add_test(BulletIntegrationConvertShapeTest ConvertShapeTest.cpp LIBRARIES MagnumBulletIntegration)

--- a/src/Magnum/BulletIntegration/Test/CMakeLists.txt
+++ b/src/Magnum/BulletIntegration/Test/CMakeLists.txt
@@ -25,5 +25,5 @@
 #   DEALINGS IN THE SOFTWARE.
 #
 
-corrade_add_test(BulletIntegrationTest IntegrationTest.cpp LIBRARIES MagnumBulletIntegration ${BULLET_LIBRARIES})
+corrade_add_test(BulletIntegrationTest IntegrationTest.cpp LIBRARIES MagnumBulletIntegration)
 corrade_add_test(BulletIntegrationConvertShapeTest ConvertShapeTest.cpp LIBRARIES MagnumBulletIntegration)

--- a/src/Magnum/BulletIntegration/Test/IntegrationTest.cpp
+++ b/src/Magnum/BulletIntegration/Test/IntegrationTest.cpp
@@ -43,6 +43,8 @@ struct IntegrationTest: TestSuite::Tester {
     void vector();
     void matrix3();
     void matrix4();
+    void quaternion();
+
     void debugDrawMode();
 };
 
@@ -50,6 +52,7 @@ IntegrationTest::IntegrationTest() {
     addTests({&IntegrationTest::vector,
               &IntegrationTest::matrix3,
               &IntegrationTest::matrix4,
+              &IntegrationTest::quaternion,
               &IntegrationTest::debugDrawMode});
 }
 
@@ -93,6 +96,14 @@ void IntegrationTest::matrix4() {
     const btTransform btA = btTransform(a);
     CORRADE_COMPARE(Quaternion{btA.getRotation()}, rotation);
     CORRADE_COMPARE(Vector3{btA.getOrigin()}, translation);
+}
+
+void IntegrationTest::quaternion() {
+    Quaternion a{{1.0f, 2.0f, 3.0f}, 4.0f};
+    btQuaternion b{1.0f, 2.0f, 3.0f, 4.0f};
+
+    CORRADE_COMPARE(Quaternion{b}, a);
+    CORRADE_VERIFY(btQuaternion{a} == b);
 }
 
 void IntegrationTest::debugDrawMode() {

--- a/src/Magnum/BulletIntegration/Test/IntegrationTest.cpp
+++ b/src/Magnum/BulletIntegration/Test/IntegrationTest.cpp
@@ -28,7 +28,7 @@
 #include <sstream>
 #include <Corrade/TestSuite/Tester.h>
 
-#include "Magnum/Magnum.h"
+#include <Magnum/Magnum.h>
 #include "Magnum/BulletIntegration/Integration.h"
 #include "Magnum/BulletIntegration/DebugDraw.h"
 
@@ -41,13 +41,15 @@ struct IntegrationTest: TestSuite::Tester {
     explicit IntegrationTest();
 
     void vector();
-    void matrix();
+    void matrix3();
+    void matrix4();
     void debugDrawMode();
 };
 
 IntegrationTest::IntegrationTest() {
     addTests({&IntegrationTest::vector,
-              &IntegrationTest::matrix,
+              &IntegrationTest::matrix3,
+              &IntegrationTest::matrix4,
               &IntegrationTest::debugDrawMode});
 }
 
@@ -60,13 +62,13 @@ void IntegrationTest::vector() {
     CORRADE_VERIFY(btVector3(a) == b);
 }
 
-void IntegrationTest::matrix() {
-    Matrix3 a{Vector3{3.0f,  5.0f, 8.0f},
-              Vector3{4.5f,  4.0f, 7.0f},
-              Vector3{7.9f, -1.0f, 8.0f}};
-    btMatrix3x3 b{3.0f,  5.0f, 8.0f,
-                  4.5f,  4.0f, 7.0f,
-                  7.9f, -1.0f, 8.0f};
+void IntegrationTest::matrix3() {
+    constexpr Matrix3 a{Vector3{3.0f,  5.0f, 8.0f},
+                        Vector3{4.5f,  4.0f, 7.0f},
+                        Vector3{7.9f, -1.0f, 8.0f}};
+    const btMatrix3x3 b{3.0f,  5.0f, 8.0f,
+                        4.5f,  4.0f, 7.0f,
+                        7.9f, -1.0f, 8.0f};
 
     CORRADE_COMPARE(Matrix3{b}, a);
 
@@ -77,6 +79,20 @@ void IntegrationTest::matrix() {
     const btScalar* pb = &b[0][0];
     for(std::size_t i = 0; i < 9; ++i, ++pb, ++pa)
         CORRADE_COMPARE(*pa, *pb);
+}
+
+void IntegrationTest::matrix4() {
+    const Quaternion rotation = Quaternion{{1.0f, 2.0f, 3.0f}, 4.0f}.normalized();
+    constexpr Vector3 translation{1.0f, 2.0f, 3.0f};
+
+    const Matrix4 a = Matrix4::from(rotation.toMatrix(), translation);
+    const btTransform b{btQuaternion{rotation}, btVector3{translation}};
+
+    CORRADE_COMPARE(Matrix4{b}, a);
+
+    const btTransform btA = btTransform(a);
+    CORRADE_COMPARE(Quaternion{btA.getRotation()}, rotation);
+    CORRADE_COMPARE(Vector3{btA.getOrigin()}, translation);
 }
 
 void IntegrationTest::debugDrawMode() {

--- a/src/Magnum/BulletIntegration/Test/IntegrationTest.cpp
+++ b/src/Magnum/BulletIntegration/Test/IntegrationTest.cpp
@@ -29,15 +29,13 @@
 #include <Corrade/TestSuite/Tester.h>
 
 #include <Magnum/Magnum.h>
-
 #include <Magnum/Math/Vector3.h>
-
 #include <Magnum/SceneGraph/MatrixTransformation3D.h>
 #include <Magnum/SceneGraph/Object.h>
 #include <Magnum/SceneGraph/Scene.h>
 
-#include "Magnum/BulletIntegration/Integration.h"
 #include "Magnum/BulletIntegration/DebugDraw.h"
+#include "Magnum/BulletIntegration/Integration.h"
 #include "Magnum/BulletIntegration/MotionState.h"
 
 #include <BulletDynamics/btBulletDynamicsCommon.h>


### PR DESCRIPTION
Hi @mosra !

Here is the mentioned pullrequest to finally fix the behaviour of `BulletIntegration::MotionState` with parents in the SceneGraph.

While I was at it, I added more conversions, a test and did the `@todoc` in MotionState.h

Regards, Squareys.
