### PR TITLE
Allow Bullet integration in the face of -DBUILD_DEPRECATED=OFF

### DIFF
--- a/src/Magnum/BulletIntegration/DebugDraw.cpp
+++ b/src/Magnum/BulletIntegration/DebugDraw.cpp
@@ -55,7 +55,7 @@ Debug& operator<<(Debug& debug, const DebugDraw::DebugMode value) {
 }
 
 DebugDraw::DebugDraw(const std::size_t initialBufferCapacity): _mesh{MeshPrimitive::Lines} {
-    _mesh.addVertexBuffer(_buffer, 0, Shaders::VertexColor3D::Position{}, Shaders::VertexColor3D::Color{});
+    _mesh.addVertexBuffer(_buffer, 0, Shaders::VertexColor3D::Position{}, Shaders::VertexColor3D::Color{Shaders::VertexColor3D::Color::Components::Three});
     _bufferData.reserve(initialBufferCapacity*4);
 }
 


### PR DESCRIPTION
Bullet Integration should probably only use non-deprecated functions / methods.