### PR TITLE
BulletIntegration: Remove DebugOutput include from DebugDraw

### DIFF
--- a/src/Magnum/BulletIntegration/DebugDraw.h
+++ b/src/Magnum/BulletIntegration/DebugDraw.h
@@ -34,7 +34,6 @@
 #include <Corrade/Containers/ArrayView.h>
 #include <Corrade/Utility/Macros.h>
 #include <Magnum/Buffer.h>
-#include <Magnum/DebugOutput.h>
 #include <Magnum/Magnum.h>
 #include <Magnum/Mesh.h>
 #include <Magnum/Shaders/VertexColor.h>


### PR DESCRIPTION
Hi @mosra !

This include prevents build with emscripten (as it is not available there) and is not required.

Cheers, Jonathan