### PR TITLE
fix to allow building on both Ubuntu 16.04 and 18.04.

### DIFF
--- a/package/debian/control
+++ b/package/debian/control
@@ -18,7 +18,7 @@ Description: Magnum Integration development files
 Package: magnum-integration
 Section: libs
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}, magnum, libbulletcollision2.83.6
+Depends: ${shlibs:Depends}, ${misc:Depends}, magnum, libbulletcollision2.83.6|libbullet2.87
 Description: Integration libraries for the Magnum C++11/C++14 graphics engine
  Magnum is 2D/3D graphics engine written in C++11 and modern OpenGL. Its goal
  is to simplify low-level graphics development and interaction with OpenGL


### PR DESCRIPTION
As promised in https://github.com/mosra/magnum/issues/248, here is a PR that will allow builds to work for both Ubuntu 18.04 and 16.04. Note that some of the changes are also to allow the build to work correctly in Launchpad, as it builds from a clean chroot every time dependencies may not be available.