### PR TITLE
BulletIntegration: fix Matrix3x3 conversion along with unit tests

### DIFF
--- a/src/Magnum/BulletIntegration/Integration.h
+++ b/src/Magnum/BulletIntegration/Integration.h
@@ -52,15 +52,15 @@ template<> struct VectorConverter<3, btScalar, btVector3> {
 
 template<> struct RectangularMatrixConverter<3, 3, btScalar, btMatrix3x3> {
     static RectangularMatrix<3, 3, Float> from(const btMatrix3x3& other) {
-        return {Vector<3, Float>(other[0]),
-                Vector<3, Float>(other[1]),
-                Vector<3, Float>(other[2])};
+        return {Vector<3, Float>(other.getColumn(0)),
+                Vector<3, Float>(other.getColumn(1)),
+                Vector<3, Float>(other.getColumn(2))};
     }
 
     static btMatrix3x3 to(const RectangularMatrix<3, 3, Float>& other) {
-        return {other[0][0], other[0][1], other[0][2],
-                other[1][0], other[1][1], other[1][2],
-                other[2][0], other[2][1], other[2][2]};
+        return {other[0][0], other[1][0], other[2][0],
+                other[0][1], other[1][1], other[2][1],
+                other[0][2], other[1][2], other[2][2]};
     }
 };
 

--- a/src/Magnum/BulletIntegration/MotionState.cpp
+++ b/src/Magnum/BulletIntegration/MotionState.cpp
@@ -43,12 +43,14 @@ MotionState::MotionState(SceneGraph::AbstractBasicObject3D<btScalar>& object, Sc
 MotionState::~MotionState() = default;
 
 void MotionState::getWorldTransform(btTransform& worldTrans) const {
+    Debug{} << "getWorldTransform";
     const Matrix4 transformation = object().transformationMatrix();
     worldTrans.setOrigin(btVector3(transformation.translation()));
     worldTrans.setBasis(btMatrix3x3(transformation.rotationScaling()));
 }
 
 void MotionState::setWorldTransform(const btTransform& worldTrans) {
+    Debug{} << "setWorldTransform()";
     const Vector3 position = Vector3{worldTrans.getOrigin()};
     const Vector3 axis = Vector3{worldTrans.getRotation().getAxis()};
     const Float rotation = worldTrans.getRotation().getAngle();

--- a/src/Magnum/BulletIntegration/Test/IntegrationTest.cpp
+++ b/src/Magnum/BulletIntegration/Test/IntegrationTest.cpp
@@ -63,12 +63,15 @@ void IntegrationTest::vector() {
 }
 
 void IntegrationTest::matrix3() {
+    /* Magnum is column-major */
     constexpr Matrix3 a{Vector3{3.0f,  5.0f, 8.0f},
                         Vector3{4.5f,  4.0f, 7.0f},
                         Vector3{7.9f, -1.0f, 8.0f}};
-    const btMatrix3x3 b{3.0f,  5.0f, 8.0f,
-                        4.5f,  4.0f, 7.0f,
-                        7.9f, -1.0f, 8.0f};
+
+    /* Bullet is row-major */
+    const btMatrix3x3 b{3.0f,  4.5f,  7.9f,
+                        5.0f,  4.0f, -1.0f,
+                        8.0f,  7.0f,  8.0f};
 
     CORRADE_COMPARE(Matrix3{b}, a);
 


### PR DESCRIPTION
Bullet matrices are row-major, Magnum matrices are column-major.
The `Matrix3x3` unit test did not account for this and tested the wrong behavior.
The test for `Matrix4x4` seems fine, haven't looked in detail, though.

This probably hasn't been noticed before because `BulletIntegration::MotionState` uses the `Matrix3x3` conversion only in the Magnum -> Bullet direction, and this is typically only done once during `btRigidBody` initialization. The bullet example in magnum-examples uses identity rotation at initialization...