### PR TITLE
BulletIntegration: improve MotionState documentation

### DIFF
--- a/doc/snippets/BulletIntegration.cpp
+++ b/doc/snippets/BulletIntegration.cpp
@@ -78,6 +78,12 @@ auto rigidBody = new btRigidBody{20.0f, &motionState->btMotionState(), collision
 btWorld->addRigidBody(rigidBody);
 /* [MotionState-usage] */
 
+/* [MotionState-update] */
+btTransform transform;
+rigidBody->getMotionState()->getWorldTransform(transform);
+rigidBody->setWorldTransform(transform);
+/* [MotionState-update] */
+
 /* [MotionState-usage-after] */
 rigidBody->setMotionState(&motionState->btMotionState());
 /* [MotionState-usage-after] */

--- a/src/Magnum/BulletIntegration/MotionState.h
+++ b/src/Magnum/BulletIntegration/MotionState.h
@@ -51,10 +51,14 @@ a @ref SceneGraph::Object by passing the motion state in its constructor:
 
 @snippet BulletIntegration.cpp MotionState-usage
 
-This way, the @p rigidBody will be affected when transformation of the object
-is changed from the scenegraph and also the other way around --- the @p object
-gets its position updated when the Bullet world changes. It's also possible to
-attach the motion state afterwards:
+This way, the scenegraph will be affected automatically by the Bullet
+simulation. Note that the other direction only has effect during creation of
+the @p btRigidBody --- if you need to update the Bullet state with new
+transforms from the scenegraph you have to do it manually:
+
+@snippet BulletIntegration.cpp MotionState-update
+
+It's also possible to attach the motion state afterwards:
 
 @snippet BulletIntegration.cpp MotionState-usage-after
 


### PR DESCRIPTION
The documentation gives the impression that SceneGraph changes are automatically propagated to the Bullet world - this is not the case. The SceneGraph transforms are only used for initialization.

Reference: https://github.com/bulletphysics/bullet3/blob/c993175a5859e48783cf2c490947d826be5649b2/src/BulletDynamics/Dynamics/btRigidBody.cpp#L67
(try searching the file for other occurences of `MotionState::getWorldTransform()` - the only other occurrence is for kinematic objects)

This modifies the documentation accordingly and adds a snippet on how to manually sync SceneGraph -> Bullet.