### PR TITLE
ImGuiIntegration: add imageButton()

### DIFF
--- a/src/Magnum/ImGuiIntegration/Test/ContextGLTest.cpp
+++ b/src/Magnum/ImGuiIntegration/Test/ContextGLTest.cpp
@@ -26,6 +26,7 @@
 
 #include <sstream>
 #include <Corrade/TestSuite/Compare/Container.h>
+#include <Corrade/Utility/System.h>
 #include <Magnum/Magnum.h>
 #include <Magnum/Math/Vector3.h>
 #include <Magnum/GL/OpenGLTester.h>
@@ -253,6 +254,8 @@ void ContextGLTest::constructMove() {
 
     c.drawFrame();
 
+    Corrade::Utility::System::sleep(1);
+
     /* ImGui doesn't draw anything the first frame so do it twice. */
     c.newFrame();
     ImGui::Button("test");
@@ -290,6 +293,8 @@ void ContextGLTest::frame() {
 
     MAGNUM_VERIFY_NO_GL_ERROR();
 
+    Corrade::Utility::System::sleep(1);
+
     /* This should render stuff now */
     c.newFrame();
     ImGui::Button("test");
@@ -306,6 +311,8 @@ void ContextGLTest::frameZeroSize() {
     c.drawFrame();
 
     MAGNUM_VERIFY_NO_GL_ERROR();
+
+    Corrade::Utility::System::sleep(1);
 
     c.newFrame();
 
@@ -338,6 +345,8 @@ void ContextGLTest::relayout() {
     CORRADE_COMPARE(ImGui::GetIO().Fonts->Fonts[0]->GetDebugName(), std::string{"ProggyClean.ttf, 13px [SCALED]"});
     CORRADE_COMPARE(ImGui::GetIO().Fonts->Fonts[0]->FontSize, 13.0f);
 
+    Corrade::Utility::System::sleep(1);
+
     /* This should render stuff now */
     c.newFrame();
     ImGui::Button("test");
@@ -367,6 +376,8 @@ void ContextGLTest::relayoutDpiChange() {
     CORRADE_COMPARE(ImGui::GetIO().Fonts->Fonts.size(), 1);
     CORRADE_COMPARE(ImGui::GetIO().Fonts->Fonts[0]->GetDebugName(), std::string{"ProggyClean.ttf, 13px [SCALED]"});
     CORRADE_COMPARE(ImGui::GetIO().Fonts->Fonts[0]->FontSize, 26.0f); /* 2x */
+
+    Corrade::Utility::System::sleep(1);
 
     /* This should render stuff now */
     c.newFrame();
@@ -402,6 +413,8 @@ void ContextGLTest::relayoutDpiChangeCustomFont() {
 
     c.relayout({200, 200}, {70, 70}, {400, 400});
 
+    Corrade::Utility::System::sleep(1);
+
     /* This should render stuff now */
     c.newFrame();
     ImGui::Button("test");
@@ -423,6 +436,8 @@ void ContextGLTest::relayoutZeroSize() {
     MAGNUM_VERIFY_NO_GL_ERROR();
 
     c.relayout({100, 0});
+
+    Corrade::Utility::System::sleep(1);
 
     /* This should render stuff now */
     c.newFrame();
@@ -541,6 +556,8 @@ void ContextGLTest::multipleContexts() {
     b.drawFrame();
     MAGNUM_VERIFY_NO_GL_ERROR();
     CORRADE_COMPARE(ImGui::GetCurrentContext(), b.context());
+
+    Corrade::Utility::System::sleep(1);
 
     /* This should render stuff now */
     a.newFrame();

--- a/src/Magnum/ImGuiIntegration/Test/WidgetsGLTest.cpp
+++ b/src/Magnum/ImGuiIntegration/Test/WidgetsGLTest.cpp
@@ -25,6 +25,7 @@
 */
 
 #include <sstream>
+#include <Corrade/Utility/System.h>
 #include <Magnum/Magnum.h>
 #include <Magnum/GL/TextureFormat.h>
 #include <Magnum/GL/OpenGLTester.h>
@@ -38,10 +39,12 @@ struct WidgetsGLTest: GL::OpenGLTester {
     explicit WidgetsGLTest();
 
     void image();
+    void imageButton();
 };
 
 WidgetsGLTest::WidgetsGLTest() {
-    addTests({&WidgetsGLTest::image});
+    addTests({&WidgetsGLTest::image,
+              &WidgetsGLTest::imageButton});
 
     GL::Renderer::enable(GL::Renderer::Feature::Blending);
     GL::Renderer::setBlendEquation(GL::Renderer::BlendEquation::Add, GL::Renderer::BlendEquation::Add);
@@ -63,9 +66,33 @@ void WidgetsGLTest::image() {
     GL::Texture2D texture;
     texture.setStorage(1, GL::TextureFormat::RGB8, {1, 1});
 
+    Corrade::Utility::System::sleep(1);
+
     c.newFrame();
 
     ImGuiIntegration::image(texture, {100, 100});
+
+    c.drawFrame();
+
+    MAGNUM_VERIFY_NO_GL_ERROR();
+}
+
+void WidgetsGLTest::imageButton() {
+    /* Checks compilation and no GL errors only */
+    Context c{{200, 200}};
+
+    /* Again a dummy frame first as ImGui doesn't draw anything the first frame */
+    c.newFrame();
+    c.drawFrame();
+
+    GL::Texture2D texture;
+    texture.setStorage(1, GL::TextureFormat::RGB8, {1, 1});
+
+    Corrade::Utility::System::sleep(1);
+
+    c.newFrame();
+
+    ImGuiIntegration::imageButton(texture, {100, 100});
 
     c.drawFrame();
 

--- a/src/Magnum/ImGuiIntegration/Widgets.h
+++ b/src/Magnum/ImGuiIntegration/Widgets.h
@@ -29,7 +29,7 @@
 */
 
 /** @file
- * @brief Functions @ref Magnum::ImGuiIntegration::image(), @ref Magnum::ImGuiIntegration::imageButton()
+ * @brief Function @ref Magnum::ImGuiIntegration::image(), @ref Magnum::ImGuiIntegration::imageButton()
  */
 
 #include <imgui.h>
@@ -68,10 +68,10 @@ inline void image(GL::Texture2D& texture, const Vector2& size,
 @param tintColor        Tint color, default @cpp 0xffffffff_rgbaf @ce
 */
 inline bool imageButton(GL::Texture2D& texture, const Vector2& size,
-                        const Range2D& uvRange = {{}, Vector2{1.0f}},
-                        const int& framePadding = -1,
-                        const Color4& backgroundColor = Color4{0.0f},
-                        const Color4& tintColor = Color4{1.0f})
+    const Range2D& uvRange = {{}, Vector2{1.0f}},
+    const int& framePadding = -1,
+    const Color4& backgroundColor = Color4{0.0f},
+    const Color4& tintColor = Color4{1.0f})
 {
     return ImGui::ImageButton(static_cast<ImTextureID>(&texture), ImVec2(size), ImVec2(uvRange.min()), ImVec2(uvRange.max()), framePadding, ImColor(backgroundColor), ImColor(tintColor));
 }

--- a/src/Magnum/ImGuiIntegration/Widgets.h
+++ b/src/Magnum/ImGuiIntegration/Widgets.h
@@ -55,7 +55,7 @@ inline void image(GL::Texture2D& texture, const Vector2& size,
     const Color4& tintColor = Color4{1.0f},
     const Color4& borderColor = {})
 {
-    ImGui::Image(static_cast<ImTextureID>(&texture), ImVec2(size), ImVec2(uvRange.min()), ImVec2(uvRange.max()), ImColor(tintColor), ImColor(borderColor));
+    ImGui::Image(static_cast<ImTextureID>(&texture), ImVec2(size), ImVec2(uvRange.topLeft()), ImVec2(uvRange.bottomRight()), ImColor(tintColor), ImColor(borderColor));
 }
 
 /**
@@ -70,10 +70,10 @@ inline void image(GL::Texture2D& texture, const Vector2& size,
 inline bool imageButton(GL::Texture2D& texture, const Vector2& size,
     const Range2D& uvRange = {{}, Vector2{1.0f}},
     const int& framePadding = -1,
-    const Color4& backgroundColor = Color4{0.0f},
+    const Color4& backgroundColor = Color4{0.0f, 0.0f},
     const Color4& tintColor = Color4{1.0f})
 {
-    return ImGui::ImageButton(static_cast<ImTextureID>(&texture), ImVec2(size), ImVec2(uvRange.min()), ImVec2(uvRange.max()), framePadding, ImColor(backgroundColor), ImColor(tintColor));
+    return ImGui::ImageButton(static_cast<ImTextureID>(&texture), ImVec2(size), ImVec2(uvRange.topLeft()), ImVec2(uvRange.bottomRight()), framePadding, ImColor(backgroundColor), ImColor(tintColor));
 }
 
 }}

--- a/src/Magnum/ImGuiIntegration/Widgets.h
+++ b/src/Magnum/ImGuiIntegration/Widgets.h
@@ -29,7 +29,7 @@
 */
 
 /** @file
- * @brief Function @ref Magnum::ImGuiIntegration::image()
+ * @brief Functions @ref Magnum::ImGuiIntegration::image(), @ref Magnum::ImGuiIntegration::imageButton()
  */
 
 #include <imgui.h>
@@ -56,6 +56,24 @@ inline void image(GL::Texture2D& texture, const Vector2& size,
     const Color4& borderColor = {})
 {
     ImGui::Image(static_cast<ImTextureID>(&texture), ImVec2(size), ImVec2(uvRange.min()), ImVec2(uvRange.max()), ImColor(tintColor), ImColor(borderColor));
+}
+
+/**
+@brief ImageButton widget displaying a @ref GL::Texture2D
+@param texture          Texture to display
+@param size             Widget size
+@param uvRange          UV range on the texture (covers the whole texture by default)
+@param framePadding     Frame padding, negative values use the default frame padding.
+@param backgroundColor  Background color, default @cpp 0x00000000_rgbaf @ce
+@param tintColor        Tint color, default @cpp 0xffffffff_rgbaf @ce
+*/
+inline bool imageButton(GL::Texture2D& texture, const Vector2& size,
+                        const Range2D& uvRange = {{}, Vector2{1.0f}},
+                        const int& framePadding = -1,
+                        const Color4& backgroundColor = Color4{0.0f},
+                        const Color4& tintColor = Color4{1.0f})
+{
+    return ImGui::ImageButton(static_cast<ImTextureID>(&texture), ImVec2(size), ImVec2(uvRange.min()), ImVec2(uvRange.max()), framePadding, ImColor(backgroundColor), ImColor(tintColor));
 }
 
 }}


### PR DESCRIPTION
Also adds the corresponding test in ImGuiWidgetsGLTest.

Since I tested with ImGui 1.68 WIP, which [apparently needs some time to display stuff](https://github.com/ocornut/imgui/commit/3c07ec6a6126fb6b98523a9685d1f0f78ca3c40c), I had to edit both ImGuiWidgetsGLTest and ImGuiContextGLTest to add some delay between the dummy first frame and the actual test frames.

Review and feedback are welcome!