### PR TITLE
Eigen integration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,7 @@ find_package(Magnum REQUIRED)
 # Parts of the library
 option(WITH_BULLET "Build BulletIntegration library" OFF)
 option(WITH_DART "Build DartIntegration library" OFF)
+option(WITH_EIGEN "Build EigenIntegration library" OFF)
 option(WITH_GLM "Build GlmIntegration library" OFF)
 option(WITH_IMGUI "Build ImGuiIntegration library" OFF)
 option(WITH_OVR "Build OvrIntegration library" OFF)

--- a/doc/building-integration.dox
+++ b/doc/building-integration.dox
@@ -290,6 +290,8 @@ manually:
     library. Depends on [Bullet Physics](http://bulletphysics.org/).
 -   `WITH_DART` --- Build the @ref DartIntegration "DartIntegration" library.
     Depends on [DART](http://dartsim.github.io/).
+-   `WITH_EIGEN` --- Build the @ref EigenIntegration "EigenIntegration"
+    library. Depends on [Eigen](http://eigen.tuxfamily.org/).
 -   `WITH_GLM` --- Build the @ref GlmIntegration "GlmIntegration" library.
     Depends on [GLM](https://glm.g-truc.net/).
 -   `WITH_IMGUI` --- Build the @ref ImGuiIntegration "ImGuiIntegration" library.

--- a/doc/changelog-integration.dox
+++ b/doc/changelog-integration.dox
@@ -34,6 +34,9 @@ namespace Magnum {
 
 @subsection changelog-integration-latest-new New features
 
+-   New @ref EigenIntegration library, providing conversion of math types from
+    and to [Eigen](http://eigen.tuxfamily.org/) APIs (see
+    [mosra/magnum-integration#40](https://github.com/mosra/magnum-integration/pull/40))
 -   New @ref ImGuiIntegration::imageButton() widget for drawing an image button
     out of @ref GL::Texture2D (see [mosra/magnum-integration#38](https://github.com/mosra/magnum-integration/pull/38))
 

--- a/doc/cmake-integration.dox
+++ b/doc/cmake-integration.dox
@@ -58,6 +58,7 @@ This command tries to find Magnum integration library and then defines:
 This command alone is useless without specifying the components:
 
 -   `Bullet` --- @ref BulletIntegration library
+-   `Eigen` --- @ref EigenIntegration library
 -   `Dart`  --- @ref DartIntegration library
 -   `Glm` --- @ref GlmIntegration library
 -   `ImGui` --- @ref ImGuiIntegration library

--- a/doc/custom-buildsystems-integration-order.dot
+++ b/doc/custom-buildsystems-integration-order.dot
@@ -38,6 +38,7 @@ digraph "Magnum Integration dependency order" {
     MagnumTrade [style=solid style=solid label="Magnum\nTrade" class="m-info"]
 
     MagnumBulletIntegration [label="Magnum\nBulletIntegration" class="m-info"]
+    MagnumEigenIntegration [label="Magnum\nEigenIntegration" class="m-info"]
     MagnumDartIntegration [label="Magnum\nDartIntegration" class="m-info"]
     MagnumGlmIntegration [label="Magnum\nGlmIntegration" class="m-info"]
     MagnumImGuiIntegration [label="Magnum\nImGuiIntegration" class="m-info"]
@@ -61,6 +62,7 @@ digraph "Magnum Integration dependency order" {
     MagnumDartIntegration -> MagnumSceneGraph
     MagnumDartIntegration -> MagnumShaders
 
+    MagnumEigenIntegration -> Magnum
     MagnumGlmIntegration -> Magnum
     MagnumImGuiIntegration -> MagnumGL
     MagnumOvrIntegration -> MagnumGL

--- a/doc/namespaces.dox
+++ b/doc/namespaces.dox
@@ -93,6 +93,49 @@ See @ref building-integration and @ref cmake-integration for more information.
     Attribution is required for public use.
 */
 
+/** @dir Magnum/EigenIntegration
+ * @brief Namespace @ref Magnum::EigenIntegration
+ */
+/** @namespace Magnum::EigenIntegration
+@brief Integration with Eigen
+
+Conversion of math types from and to the Eigen library.
+
+This library depends on the [Eigen](http://eigen.tuxfamily.org/) library and is
+built if `WITH_EIGEN` is enabled when building Magnum Integration. To use this
+library with CMake, you need to request the `Eigen` component of the
+`MagnumIntegration` package and link to the `MagnumIntegration::Eigen` target:
+
+@code{.cmake}
+find_package(MagnumIntegration REQUIRED Eigen)
+
+# ...
+target_link_libraries(your-app MagnumIntegration::Eigen)
+@endcode
+
+The integration routines are provided in the
+@ref Magnum/EigenIntegration/Integration.h header, see its documentation
+for more information. See also @ref building-integration and
+@ref cmake-integration.
+
+@m_class{m-block m-warning}
+
+@thirdparty This library makes use of the
+    [Eigen](http://eigen.tuxfamily.org/),
+    released under @m_class{m-label m-warning} **MPL 2.0**
+    ([license text](http://www.mozilla.org/MPL/2.0),
+    [choosealicense.com](https://choosealicense.com/licenses/mpl-2.0/)).
+    Attribution is required for public use, source code of licensed files and
+    modifications of these files have to be made available under the same
+    license. Additionally, some parts rely on third-party code licensed under
+    @m_class{m-label m-warning} **LGPLv3**
+    ([license text](http://eigen.tuxfamily.org/index.php?title=Main_Page#License),
+    [choosealicense.com](https://choosealicense.com/licenses/lgpl-3.0/)),
+    requiring either dynamic linking or full source disclosure for public use.
+    See the [license notes](http://eigen.tuxfamily.org/index.php?title=Main_Page#License)
+    for details.
+
+*/
 /** @dir Magnum/GlmIntegration
  * @brief Namespace @ref Magnum::GlmIntegration
  */

--- a/doc/snippets/CMakeLists.txt
+++ b/doc/snippets/CMakeLists.txt
@@ -44,6 +44,12 @@ if(WITH_DART)
     set_target_properties(snippets-DartIntegration PROPERTIES FOLDER "Magnum/doc/snippets")
 endif()
 
+if(WITH_EIGEN)
+    add_library(snippets-EigenIntegration STATIC EigenIntegration.cpp)
+    target_link_libraries(snippets-EigenIntegration PRIVATE MagnumEigenIntegration)
+    set_target_properties(snippets-EigenIntegration PROPERTIES FOLDER "Magnum/doc/snippets")
+endif()
+
 if(WITH_GLM)
     add_library(snippets-GlmIntegration STATIC GlmIntegration.cpp)
     target_link_libraries(snippets-GlmIntegration PRIVATE MagnumGlmIntegration)

--- a/doc/snippets/EigenIntegration.cpp
+++ b/doc/snippets/EigenIntegration.cpp
@@ -1,0 +1,64 @@
+/*
+    This file is part of Magnum.
+
+    Copyright © 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018, 2019
+              Vladimír Vondruš <mosra@centrum.cz>
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included
+    in all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+#include "Magnum/Magnum.h"
+#include "Magnum/EigenIntegration/GeometryIntegration.h"
+#include "Magnum/Math/Matrix3.h"
+#include "Magnum/Math/Matrix4.h"
+
+using namespace Magnum;
+using namespace Magnum::Math::Literals;
+
+int main() {
+{
+/* [Integration] */
+Eigen::Vector3f a{1.0f, 2.0f, 3.0f};
+Vector3 b(a);
+
+auto c = Matrix3::rotation(35.0_degf);
+
+// It's not possible to convert using Eigen::Matrix3f(c)
+auto d = EigenIntegration::eigenCast<Eigen::Matrix3f>(c);
+
+Debug{} << Eigen::Array3i{1, 42, -3}; // prints   1
+                                      //         42
+                                      //         -3
+/* [Integration] */
+static_cast<void>(d);
+}
+
+{
+/* [GeometryIntegration] */
+auto a = Matrix3::translation({-1.5f, 0.3f})*
+         Matrix3::rotation(25.0_degf)*
+         Matrix3::scaling({1.23f, 2.0f});
+auto b = Eigen::Affine2f(a);
+
+auto c = Matrix4d(Eigen::Isometry3d::Identity());
+/* [GeometryIntegration] */
+static_cast<void>(b);
+static_cast<void>(c);
+}
+}

--- a/modules/FindMagnumIntegration.cmake
+++ b/modules/FindMagnumIntegration.cmake
@@ -15,6 +15,7 @@
 #
 #  Bullet                       - Bullet Physics integration library
 #  Dart                         - Dart Physics integration library
+#  Eigen                        - Eigen integration library
 #  Glm                          - GLM integration library
 #  ImGui                        - ImGui integration library
 #  Ovr                          - Oculus SDK integration library
@@ -96,7 +97,8 @@ mark_as_advanced(MAGNUMINTEGRATION_INCLUDE_DIR)
 
 # Component distinction (listing them explicitly to avoid mistakes with finding
 # components from other repositories)
-set(_MAGNUMINTEGRATION_LIBRARY_COMPONENT_LIST Bullet Dart ImGui Glm Ovr)
+set(_MAGNUMINTEGRATION_LIBRARY_COMPONENT_LIST Bullet Dart Eigen ImGui Glm Ovr)
+set(_MAGNUMINTEGRATION_HEADER_ONLY_COMPONENT_LIST Eigen)
 
 # Inter-component dependencies (none yet)
 # set(_MAGNUMINTEGRATION_Component_DEPENDENCIES Dependency)
@@ -124,7 +126,7 @@ endif()
 
 # Convert components lists to regular expressions so I can use if(MATCHES).
 # TODO: Drop this once CMake 3.3 and if(IN_LIST) can be used
-foreach(_WHAT LIBRARY)
+foreach(_WHAT LIBRARY HEADER_ONLY)
     string(REPLACE ";" "|" _MAGNUMINTEGRATION_${_WHAT}_COMPONENTS "${_MAGNUMINTEGRATION_${_WHAT}_COMPONENT_LIST}")
     set(_MAGNUMINTEGRATION_${_WHAT}_COMPONENTS "^(${_MAGNUMINTEGRATION_${_WHAT}_COMPONENTS})$")
 endforeach()
@@ -140,7 +142,7 @@ foreach(_component ${MagnumIntegration_FIND_COMPONENTS})
         set(MagnumIntegration_${_component}_FOUND TRUE)
     else()
         # Library components
-        if(_component MATCHES ${_MAGNUMINTEGRATION_LIBRARY_COMPONENTS})
+        if(_component MATCHES ${_MAGNUMINTEGRATION_LIBRARY_COMPONENTS} AND NOT _component MATCHES ${_MAGNUMINTEGRATION_HEADER_ONLY_COMPONENTS})
             add_library(MagnumIntegration::${_component} UNKNOWN IMPORTED)
 
             # Try to find both debug and release version
@@ -164,6 +166,11 @@ foreach(_component ${MagnumIntegration_FIND_COMPONENTS})
             endif()
         endif()
 
+        # Header-only library components
+        if(_component MATCHES ${_MAGNUMINTEGRATION_HEADER_ONLY_COMPONENTS})
+            add_library(MagnumIntegration::${_component} INTERFACE IMPORTED)
+        endif()
+
         # Bullet integration library
         if(_component STREQUAL Bullet)
             find_package(Bullet)
@@ -183,6 +190,14 @@ foreach(_component ${MagnumIntegration_FIND_COMPONENTS})
             endforeach()
 
             set(_MAGNUMINTEGRATION_${_COMPONENT}_INCLUDE_PATH_NAMES MotionState.h)
+
+        # Eigen integration library
+        elseif(_component STREQUAL Eigen)
+            find_package(Eigen3)
+            set_property(TARGET MagnumIntegration::${_component} APPEND PROPERTY
+                INTERFACE_LINK_LIBRARIES Eigen3::Eigen)
+
+            set(_MAGNUMINTEGRATION_${_COMPONENT}_INCLUDE_PATH_NAMES Integration.h)
 
         # ImGui integration library
         elseif(_component STREQUAL ImGui)
@@ -251,7 +266,7 @@ foreach(_component ${MagnumIntegration_FIND_COMPONENTS})
         endif()
 
         # Decide if the library was found
-        if(_component MATCHES ${_MAGNUMINTEGRATION_LIBRARY_COMPONENTS} AND _MAGNUMINTEGRATION_${_COMPONENT}_INCLUDE_DIR AND (MAGNUMINTEGRATION_${_COMPONENT}_LIBRARY_DEBUG OR MAGNUMINTEGRATION_${_COMPONENT}_LIBRARY_RELEASE))
+        if(_component MATCHES ${_MAGNUMINTEGRATION_LIBRARY_COMPONENTS} AND _MAGNUMINTEGRATION_${_COMPONENT}_INCLUDE_DIR AND (_component MATCHES ${_MAGNUMINTEGRATION_HEADER_ONLY_COMPONENTS} OR MAGNUMINTEGRATION_${_COMPONENT}_LIBRARY_DEBUG OR MAGNUMINTEGRATION_${_COMPONENT}_LIBRARY_RELEASE))
             set(MagnumIntegration_${_component}_FOUND TRUE)
         else()
             set(MagnumIntegration_${_component}_FOUND FALSE)

--- a/modules/FindMagnumIntegration.cmake
+++ b/modules/FindMagnumIntegration.cmake
@@ -194,8 +194,17 @@ foreach(_component ${MagnumIntegration_FIND_COMPONENTS})
         # Eigen integration library
         elseif(_component STREQUAL Eigen)
             find_package(Eigen3)
+            # We could drop this once we can use at least 3.3.1 (Ubuntu 16.04
+            # has only 3.3 beta, which doesn't have this target yet), however
+            # for Travis and AppVeyor we're using FindEigen3.cmake from the
+            # downloaded sources (because the Eigen3Config.cmake, which
+            # produces the actual targets, is not there -- only
+            # Eigen3Config.cmake.in). See the YML files for an extended rant.
+            # Also, FindEigen3 only defines EIGEN3_INCLUDE_DIR, not even
+            # EIGEN3_INCLUDE_DIRS, so be extra careful.
+            # http://eigen.tuxfamily.org/index.php?title=ChangeLog#Eigen_3.3.1
             set_property(TARGET MagnumIntegration::${_component} APPEND PROPERTY
-                INTERFACE_LINK_LIBRARIES Eigen3::Eigen)
+                INTERFACE_INCLUDE_DIRECTORIES ${EIGEN3_INCLUDE_DIR})
 
             set(_MAGNUMINTEGRATION_${_COMPONENT}_INCLUDE_PATH_NAMES Integration.h)
 

--- a/package/archlinux/PKGBUILD
+++ b/package/archlinux/PKGBUILD
@@ -6,7 +6,7 @@ pkgdesc="Integration libraries for the Magnum C++11/C++14 graphics engine"
 arch=('i686' 'x86_64')
 url="https://magnum.graphics"
 license=('MIT')
-depends=('magnum' 'bullet' 'glm' 'libdart' 'imgui-src')
+depends=('magnum' 'bullet' 'eigen' 'glm' 'libdart' 'imgui-src')
 makedepends=('cmake' 'ninja')
 options=(!strip)
 provides=('magnum-integration-git')
@@ -23,6 +23,7 @@ build() {
         -DIMGUI_DIR=/opt/imgui \
         -DWITH_BULLET=ON \
         -DWITH_DART=ON \
+        -DWITH_EIGEN=ON \
         -DWITH_GLM=ON \
         -DWITH_IMGUI=ON \
         -DBUILD_TESTS=ON \

--- a/package/archlinux/PKGBUILD-coverage
+++ b/package/archlinux/PKGBUILD-coverage
@@ -6,7 +6,7 @@ pkgdesc="Integration libraries for the Magnum C++11/C++14 graphics engine (cover
 arch=('i686' 'x86_64')
 url="https://magnum.graphics"
 license=('MIT')
-depends=('magnum' 'bullet' 'libdart' 'imgui-src' 'gcc6')
+depends=('magnum' 'bullet' 'eigen' 'libdart' 'imgui-src' 'gcc6')
 makedepends=('cmake' 'ninja' 'lcov')
 options=(!strip)
 provides=('magnum-integration-git')
@@ -29,6 +29,7 @@ build() {
         -DIMGUI_DIR=/opt/imgui \
         -DWITH_BULLET=ON \
         -DWITH_DART=ON \
+        -DWITH_EIGEN=ON \
         -DWITH_GLM=ON \
         -DWITH_IMGUI=ON \
         -DBUILD_TESTS=ON \

--- a/package/archlinux/PKGBUILD-release
+++ b/package/archlinux/PKGBUILD-release
@@ -6,7 +6,7 @@ pkgdesc="Integration libraries for the Magnum C++11/C++14 graphics engine (debug
 arch=('i686' 'x86_64')
 url="https://magnum.graphics"
 license=('MIT')
-depends=('magnum' 'bullet' 'libdart' 'imgui-src')
+depends=('magnum' 'bullet' 'eigen' 'libdart' 'imgui-src')
 makedepends=('cmake' 'ninja')
 options=('!strip')
 provides=('magnum-integration-git')
@@ -23,6 +23,7 @@ build() {
         -DIMGUI_DIR=/opt/imgui \
         -DWITH_BULLET=ON \
         -DWITH_DART=ON \
+        -DWITH_EIGEN=ON \
         -DWITH_GLM=ON \
         -DWITH_IMGUI=ON \
         -DBUILD_TESTS=ON \
@@ -39,6 +40,7 @@ build() {
         -DIMGUI_DIR=/opt/imgui \
         -DWITH_BULLET=ON \
         -DWITH_DART=ON \
+        -DWITH_EIGEN=ON \
         -DWITH_GLM=ON \
         -DWITH_IMGUI=ON \
         -DBUILD_TESTS=ON \

--- a/package/archlinux/magnum-integration-git/PKGBUILD
+++ b/package/archlinux/magnum-integration-git/PKGBUILD
@@ -6,7 +6,7 @@ pkgdesc="Integration libraries for the Magnum C++11/C++14 graphics engine (Git v
 arch=('i686' 'x86_64')
 url="https://magnum.graphics"
 license=('MIT')
-depends=('magnum-git' 'bullet' 'glm')
+depends=('magnum-git' 'bullet' 'eigen' 'glm')
 makedepends=('cmake' 'git')
 provides=('magnum-integration')
 conflicts=('magnum-integration')
@@ -26,6 +26,7 @@ build() {
         -DCMAKE_BUILD_TYPE=Release \
         -DCMAKE_INSTALL_PREFIX=/usr \
         -DWITH_BULLET=ON \
+        -DWITH_EIGEN=ON \
         -DWITH_GLM=ON \
         -DWITH_DART=OFF \
         -DWITH_IMGUI=OFF

--- a/package/ci/appveyor-desktop-gles.bat
+++ b/package/ci/appveyor-desktop-gles.bat
@@ -63,6 +63,10 @@ cmake --build . || exit /b
 cmake --build . --target install || exit /b
 cd .. && cd ..
 
+rem Unlike ALL OTHER VARIABLES, CMAKE_MODULE_PATH chokes on backwards slashes.
+rem What the hell. This insane snippet converts them.
+set "APPVEYOR_BUILD_FOLDER_FWD=%APPVEYOR_BUILD_FOLDER:\=/%"
+
 rem Build. CMake is not able to find Debug Bullet libraries on their own so I
 rem have to force them in.
 mkdir build && cd build || exit /b
@@ -76,8 +80,11 @@ cmake .. ^
     -DBULLET_DYNAMICS_LIBRARY=%APPVEYOR_BUILD_FOLDER%/bullet/lib/BulletDynamics_Debug.lib ^
     -DBULLET_MATH_LIBRARY=%APPVEYOR_BUILD_FOLDER%/bullet/lib/LinearMath_Debug.lib ^
     -DBULLET_SOFTBODY_LIBRARY=%APPVEYOR_BUILD_FOLDER%/bullet/lib/BulletSoftBody_Debug.lib ^
+    -DCMAKE_MODULE_PATH=%APPVEYOR_BUILD_FOLDER_FWD%/deps/eigen/cmake/ ^
+    -DEIGEN3_INCLUDE_DIR=%APPVEYOR_BUILD_FOLDER%/deps/eigen/ ^
     -DWITH_BULLET=ON ^
     -DWITH_DART=OFF ^
+    -DWITH_EIGEN=ON ^
     -DWITH_GLM=ON ^
     -DWITH_IMGUI=%TARGET_GLES3% ^
     -DWITH_OVR=OFF ^

--- a/package/ci/appveyor-desktop-mingw.bat
+++ b/package/ci/appveyor-desktop-mingw.bat
@@ -64,11 +64,16 @@ cmake --build . || exit /b
 cmake --build . --target install || exit /b
 cd .. && cd ..
 
+rem Unlike ALL OTHER VARIABLES, CMAKE_MODULE_PATH chokes on backwards slashes.
+rem What the hell. This insane snippet converts them.
+set "APPVEYOR_BUILD_FOLDER_FWD=%APPVEYOR_BUILD_FOLDER:\=/%"
+
 rem Build
 rem For MinGW it's not possible to use the OVR SDK directly, the Oculus Runtime
 rem is needed to be installed, but that's apparently not possible from a
 rem command-line so I'm just disabling it.
 rem https://forums.oculus.com/community/discussion/18303/silent-installation-of-oculus-runtime-windows
+rem For a detailed Eigen rant, see appveyor-desktop.bat
 mkdir build && cd build || exit /b
 cmake .. ^
     -DCMAKE_CXX_FLAGS="--coverage" ^
@@ -76,8 +81,11 @@ cmake .. ^
     -DCMAKE_INSTALL_PREFIX=%APPVEYOR_BUILD_FOLDER%/deps ^
     -DGLM_INCLUDE_DIR=%APPVEYOR_BUILD_FOLDER%/deps/glm ^
     -DIMGUI_DIR=%APPVEYOR_BUILD_FOLDER%/deps/imgui ^
+    -DCMAKE_MODULE_PATH=%APPVEYOR_BUILD_FOLDER_FWD%/deps/eigen/cmake/ ^
+    -DEIGEN3_INCLUDE_DIR=%APPVEYOR_BUILD_FOLDER%/deps/eigen/ ^
     -DWITH_BULLET=ON ^
     -DWITH_DART=OFF ^
+    -DWITH_EIGEN=ON ^
     -DWITH_GLM=ON ^
     -DWITH_IMGUI=ON ^
     -DWITH_OVR=OFF ^

--- a/package/ci/appveyor-desktop.bat
+++ b/package/ci/appveyor-desktop.bat
@@ -60,13 +60,26 @@ cmake --build . || exit /b
 cmake --build . --target install || exit /b
 cd .. && cd ..
 
+rem Unlike ALL OTHER VARIABLES, CMAKE_MODULE_PATH chokes on backwards slashes.
+rem What the hell. This insane snippet converts them.
+set "APPVEYOR_BUILD_FOLDER_FWD=%APPVEYOR_BUILD_FOLDER:\=/%"
+
 rem Build. CMake is not able to find Debug Bullet libraries on their own so I
-rem have to force them in.
+rem have to force them in. Eigen3 is header-only but the archive is so stupid
+rem that it's not possible to just use Eigen3Config.cmake, as it's generated
+rem using CMake from Eigen3Config.cmake.in. There's FindEigen3.cmake next to
+rem it, but that doesn't help with ANYTHING AT ALL (like, what about looking
+rem one directory up, eh?! too hard?!) and also defines just EIGEN3_INCLUDE_DIR,
+rem not the Eigen3::Eigen target nor EIGEN3_INCLUDE_DIRS. Now I get why people
+rem hate CMake. It's because project rem maintainers are absolutely clueless on
+rem how to write usable find scripts with it.
 mkdir build && cd build || exit /b
 cmake .. ^
     -DCMAKE_BUILD_TYPE=Debug ^
     -DCMAKE_INSTALL_PREFIX=%APPVEYOR_BUILD_FOLDER%/deps ^
     -DCMAKE_PREFIX_PATH=%APPVEYOR_BUILD_FOLDER%/bullet ^
+    -DCMAKE_MODULE_PATH=%APPVEYOR_BUILD_FOLDER_FWD%/deps/eigen/cmake/ ^
+    -DEIGEN3_INCLUDE_DIR=%APPVEYOR_BUILD_FOLDER%/deps/eigen/ ^
     -DGLM_INCLUDE_DIR=%APPVEYOR_BUILD_FOLDER%/deps/glm ^
     -DIMGUI_DIR=%APPVEYOR_BUILD_FOLDER%/deps/imgui ^
     -DBULLET_COLLISION_LIBRARY=%APPVEYOR_BUILD_FOLDER%/bullet/lib/BulletCollision_Debug.lib ^
@@ -75,6 +88,7 @@ cmake .. ^
     -DBULLET_SOFTBODY_LIBRARY=%APPVEYOR_BUILD_FOLDER%/bullet/lib/BulletSoftBody_Debug.lib ^
     -DWITH_BULLET=ON ^
     -DWITH_DART=OFF ^
+    -DWITH_EIGEN=ON ^
     -DWITH_GLM=ON ^
     -DWITH_IMGUI=ON ^
     -DWITH_OVR=ON ^

--- a/package/ci/appveyor-rt.bat
+++ b/package/ci/appveyor-rt.bat
@@ -68,7 +68,11 @@ cmake .. ^
 cmake --build . --config Release --target install -- /m /v:m || exit /b
 cd .. && cd ..
 
-rem Crosscompile
+rem Unlike ALL OTHER VARIABLES, CMAKE_MODULE_PATH chokes on backwards slashes.
+rem What the hell. This insane snippet converts them.
+set "APPVEYOR_BUILD_FOLDER_FWD=%APPVEYOR_BUILD_FOLDER:\=/%"
+
+rem Crosscompile. For a detailed Eigen rant, see appveyor-desktop.bat.
 mkdir build-rt && cd build-rt || exit /b
 cmake .. ^
     -DCMAKE_BUILD_TYPE=Release ^
@@ -79,8 +83,11 @@ cmake .. ^
     -DOPENGLES2_INCLUDE_DIR=%APPVEYOR_BUILD_FOLDER%/angle/include ^
     -DOPENGLES3_LIBRARY=%APPVEYOR_BUILD_FOLDER%/angle/winrt/10/src/Release_x64/lib/libGLESv2.lib ^
     -DOPENGLES3_INCLUDE_DIR=%APPVEYOR_BUILD_FOLDER%/angle/include ^
+    -DCMAKE_MODULE_PATH=%APPVEYOR_BUILD_FOLDER_FWD%/deps/eigen/cmake/ ^
+    -DEIGEN3_INCLUDE_DIR=%APPVEYOR_BUILD_FOLDER%/deps/eigen/ ^
     -DWITH_BULLET=OFF ^
     -DWITH_DART=OFF ^
+    -DWITH_EIGEN=ON ^
     -DWITH_GLM=ON ^
     -DWITH_IMGUI=%TARGET_GLES3% ^
     -DWITH_OVR=OFF ^

--- a/package/ci/appveyor.yml
+++ b/package/ci/appveyor.yml
@@ -61,6 +61,10 @@ install:
 - IF "%TARGET_GLES2%" == "ON" set TARGET_GLES3=OFF
 - IF "%TARGET_GLES2%" == "OFF" set TARGET_GLES3=ON
 
+# Eigen
+- IF NOT EXIST %APPVEYOR_BUILD_FOLDER%\3.3.7.tar.bz2 appveyor DownloadFile http://bitbucket.org/eigen/eigen/get/3.3.7.tar.bz2
+- 7z x 3.3.7.tar.bz2 -o%APPVEYOR_BUILD_FOLDER%\deps && 7z x %APPVEYOR_BUILD_FOLDER%\deps\3.3.7.tar -o%APPVEYOR_BUILD_FOLDER%\deps && ren %APPVEYOR_BUILD_FOLDER%\deps\eigen-eigen-323c052e1731 eigen
+
 # GLM
 - IF NOT EXIST %APPVEYOR_BUILD_FOLDER%\0.9.9.0.zip appveyor DownloadFile https://github.com/g-truc/glm/archive/0.9.9.0.zip
 - 7z x 0.9.9.0.zip -o%APPVEYOR_BUILD_FOLDER%\deps && ren %APPVEYOR_BUILD_FOLDER%\deps\glm-0.9.9.0 glm
@@ -83,4 +87,5 @@ cache:
 - ovr_sdk_win_1.26.0_public_minimal.zip -> package/ci/appveyor-cache-reset.txt
 - 2.86.1.zip -> package/ci/appveyor-cache-reset.txt
 - 0.9.9.0.zip -> package/ci/appveyor-cache-reset.txt
+- 3.3.7.tar.bz2 -> package/ci/appveyor-cache-reset.txt
 - imgui-1.67.zip -> package/ci/appveyor-cache-reset.txt

--- a/package/ci/travis-android-arm.sh
+++ b/package/ci/travis-android-arm.sh
@@ -65,7 +65,15 @@ cmake .. \
 ninja install
 cd ../..
 
-# Crosscompile
+# Crosscompile. There's extra crazy stuff for Eigen3. It's header-only but the
+# archive is so stupid that it's not possible to just use Eigen3Config.cmake,
+# as it's generated using CMake from Eigen3Config.cmake.in. There's
+# FindEigen3.cmake next to it, but that doesn't help with ANYTHING AT ALL
+# (like, what about looking one directory up, eh?! too hard?!) and also defines
+# just EIGEN3_INCLUDE_DIR, not the Eigen3::Eigen target nor
+# EIGEN3_INCLUDE_DIRS. Now I get why people hate CMake. It's because project
+# maintainers are absolutely clueless on how to write usable find scripts with
+# it.
 mkdir build-android-arm && cd build-android-arm
 cmake .. \
     -DCMAKE_ANDROID_NDK=$TRAVIS_BUILD_DIR/android-ndk-r16b \
@@ -78,10 +86,13 @@ cmake .. \
     -DCORRADE_RC_EXECUTABLE=$HOME/deps-native/bin/corrade-rc \
     -DCMAKE_INSTALL_PREFIX=$HOME/deps \
     -DCMAKE_FIND_ROOT_PATH=$HOME/deps \
+    -DCMAKE_MODULE_PATH=$HOME/eigen/cmake/ \
+    -DEIGEN3_INCLUDE_DIR=$HOME/eigen/ \
     -DGLM_INCLUDE_DIR=$HOME/glm \
     -DIMGUI_DIR=$HOME/imgui \
     -DWITH_BULLET=OFF \
     -DWITH_DART=OFF \
+    -DWITH_EIGEN=ON \
     -DWITH_GLM=ON \
     -DWITH_IMGUI=$TARGET_GLES3 \
     -DWITH_OVR=OFF \

--- a/package/ci/travis-desktop-gles.sh
+++ b/package/ci/travis-desktop-gles.sh
@@ -61,6 +61,7 @@ cmake .. \
     -DCMAKE_INSTALL_RPATH=$HOME/swiftshader \
     -DWITH_BULLET=ON \
     -DWITH_DART=OFF \
+    -DWITH_EIGEN=ON \
     -DWITH_GLM=ON \
     -DWITH_IMGUI=$TARGET_GLES3 \
     -DWITH_OVR=OFF \

--- a/package/ci/travis-desktop.sh
+++ b/package/ci/travis-desktop.sh
@@ -71,6 +71,7 @@ cmake .. \
     -DCMAKE_BUILD_TYPE=Debug \
     -DWITH_BULLET=ON \
     -DWITH_DART=$WITH_DART \
+    -DWITH_EIGEN=ON \
     -DWITH_GLM=ON \
     -DWITH_IMGUI=ON \
     -DWITH_OVR=OFF \

--- a/package/ci/travis-emscripten.sh
+++ b/package/ci/travis-emscripten.sh
@@ -90,7 +90,15 @@ cmake .. \
 ninja install
 cd ../..
 
-# Crosscompile
+# Crosscompile. There's extra crazy stuff for Eigen3. It's header-only but the
+# archive is so stupid that it's not possible to just use Eigen3Config.cmake,
+# as it's generated using CMake from Eigen3Config.cmake.in. There's
+# FindEigen3.cmake next to it, but that doesn't help with ANYTHING AT ALL
+# (like, what about looking one directory up, eh?! too hard?!) and also defines
+# just EIGEN3_INCLUDE_DIR, not the Eigen3::Eigen target nor
+# EIGEN3_INCLUDE_DIRS. Now I get why people hate CMake. It's because project
+# maintainers are absolutely clueless on how to write usable find scripts with
+# it.
 mkdir build-emscripten && cd build-emscripten
 cmake .. \
     -DCORRADE_RC_EXECUTABLE=$HOME/deps-native/bin/corrade-rc \
@@ -99,12 +107,15 @@ cmake .. \
     -DCMAKE_BUILD_TYPE=Release \
     -DCMAKE_CXX_FLAGS_RELEASE="-DNDEBUG -O1" \
     -DCMAKE_EXE_LINKER_FLAGS_RELEASE="-O1" \
+    -DCMAKE_MODULE_PATH=$HOME/eigen/cmake/ \
+    -DEIGEN3_INCLUDE_DIR=$HOME/eigen/ \
     -DCMAKE_INSTALL_PREFIX=$HOME/deps \
     -DCMAKE_FIND_ROOT_PATH=$HOME/deps \
     -DGLM_INCLUDE_DIR=$HOME/glm \
     -DIMGUI_DIR=$HOME/imgui \
     -DWITH_BULLET=ON \
     -DWITH_DART=OFF \
+    -DWITH_EIGEN=ON \
     -DWITH_GLM=ON \
     -DWITH_IMGUI=$TARGET_GLES3 \
     -DWITH_OVR=OFF \

--- a/package/ci/travis-ios-simulator.sh
+++ b/package/ci/travis-ios-simulator.sh
@@ -62,18 +62,29 @@ cmake .. \
 set -o pipefail && cmake --build . --config Release --target install | xcpretty
 cd ../..
 
-# Crosscompile
+# Crosscompile. There's extra crazy stuff for Eigen3. It's header-only but the
+# archive is so stupid that it's not possible to just use Eigen3Config.cmake,
+# as it's generated using CMake from Eigen3Config.cmake.in. There's
+# FindEigen3.cmake next to it, but that doesn't help with ANYTHING AT ALL
+# (like, what about looking one directory up, eh?! too hard?!) and also defines
+# just EIGEN3_INCLUDE_DIR, not the Eigen3::Eigen target nor
+# EIGEN3_INCLUDE_DIRS. Now I get why people hate CMake. It's because project
+# maintainers are absolutely clueless on how to write usable find scripts with
+# it.
 mkdir build-ios && cd build-ios
 cmake .. \
     -DCMAKE_TOOLCHAIN_FILE=../toolchains/generic/iOS.cmake \
     -DCMAKE_OSX_SYSROOT=/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator.sdk \
     -DCMAKE_OSX_ARCHITECTURES="x86_64" \
+    -DCMAKE_MODULE_PATH=$HOME/eigen/cmake/ \
+    -DEIGEN3_INCLUDE_DIR=$HOME/eigen/ \
     -DCORRADE_RC_EXECUTABLE=$HOME/deps-native/bin/corrade-rc \
     -DCMAKE_INSTALL_PREFIX=$HOME/deps \
     -DGLM_INCLUDE_DIR=$HOME/glm \
     -DIMGUI_DIR=$HOME/imgui \
     -DWITH_BULLET=OFF \
     -DWITH_DART=OFF \
+    -DWITH_EIGEN=ON \
     -DWITH_GLM=ON \
     -DWITH_IMGUI=$TARGET_GLES3 \
     -DWITH_OVR=OFF \

--- a/package/ci/travis.yml
+++ b/package/ci/travis.yml
@@ -8,6 +8,7 @@ addons:
     # Needed for some snippets
     - libsdl2-dev
     - libbullet-dev
+    - libeigen3-dev
     - libglm-dev
 
 matrix:
@@ -48,6 +49,7 @@ matrix:
         # Needed for some snippets
         - libsdl2-dev
         - libbullet-dev
+        - libeigen3-dev
         - libglm-dev
   - language: cpp
     os: linux
@@ -117,6 +119,7 @@ matrix:
       apt:
         packages:
         - ninja-build
+        - libeigen3-dev
     android:
       components:
       - build-tools-22.0.1
@@ -135,6 +138,7 @@ matrix:
       apt:
         packages:
         - ninja-build
+        - libeigen3-dev
     android:
       components:
       - build-tools-22.0.1
@@ -152,6 +156,7 @@ notifications:
 cache:
   directories:
   - $HOME/cmake
+  - $HOME/eigen
   - $HOME/glm
   - $HOME/swiftshader
   - $HOME/imgui
@@ -181,12 +186,13 @@ install:
 - if [ "$TRAVIS_OS_NAME" == "osx" ] && [ "$TARGET" == "ios-simulator" ]; then gem install xcpretty; fi
 - if [ "$TRAVIS_OS_NAME" == "osx" ] && [ "$TARGET" == "emscripten" ]; then HOMEBREW_NO_AUTO_UPDATE=1 brew install emscripten && export LLVM=/usr/local/opt/emscripten/libexec/llvm/bin && emcc; fi
 
-# SDL2 (for snippets), Bullet, GLM & DART
-- if [ "$TRAVIS_OS_NAME" == "osx" ] && [ "$TARGET" == "desktop" ]; then HOMEBREW_NO_AUTO_UPDATE=1 brew install sdl2 bullet glm dartsim; fi
+# SDL2 (for snippets), Bullet, Eigen, GLM & DART for native builds
+- if [ "$TRAVIS_OS_NAME" == "osx" ] && [ "$TARGET" == "desktop" ]; then HOMEBREW_NO_AUTO_UPDATE=1 brew install sdl2 bullet eigen glm dartsim; fi
 
-# GLM for non-native builds. Put into a separate folder so it can be used
-# without including the global native system dir.
+# GLM and Eigen for non-native builds. Put into a separate folder so it can be
+# used without including the global native system dir.
 - if ( [ "$TARGET" == "android" ] || [ "$TARGET" == "ios-simulator" ] || [ "$TARGET" == "emscripten" ] ) && [ ! -e "$HOME/glm/detail" ]; then cd $HOME ; wget -nc --no-check-certificate https://github.com/g-truc/glm/archive/0.9.9.0.tar.gz && mkdir -p glm && cd glm && tar --strip-components=1 -xzf ../0.9.9.0.tar.gz && cd $TRAVIS_BUILD_DIR ; fi
+- if ( [ "$TARGET" == "android" ] || [ "$TARGET" == "ios-simulator" ] || [ "$TARGET" == "emscripten" ] ) && [ ! -e "$HOME/eigen/Eigen" ]; then cd $HOME ; wget -nc --no-check-certificate http://bitbucket.org/eigen/eigen/get/3.3.7.tar.gz && mkdir -p eigen && cd eigen && tar --strip-components=1 -xzf ../3.3.7.tar.gz && cd $TRAVIS_BUILD_DIR ; fi
 
 # DART and its dependencies. Temporarily disabled on Linux because of GCC 4 and
 # 5 ABI mismatch on 16.04, https://github.com/dartsim/dart/issues/967#issuecomment-469075835

--- a/package/debian/control
+++ b/package/debian/control
@@ -1,7 +1,7 @@
 Source: magnum-integration
 Priority: optional
 Maintainer: Vladimír Vondruš <mosra@centrum.cz>
-Build-Depends: debhelper (>= 9), cmake (>= 3.1), magnum-dev, libbullet-dev, libglm-dev
+Build-Depends: debhelper (>= 9), cmake (>= 3.1), magnum-dev, libbullet-dev, libeigen3-dev, libglm-dev
 Standards-Version: 3.9.2
 Section: libs
 Homepage: https://magnum.graphics
@@ -11,7 +11,7 @@ Vcs-Browser: https://github.com/mosra/magnum-integration
 Package: magnum-integration-dev
 Section: libdevel
 Architecture: any
-Depends: magnum-integration (= ${binary:Version}), magnum-dev, libbullet-dev, libglm-dev
+Depends: magnum-integration (= ${binary:Version}), magnum-dev, libbullet-dev, libeigen3-dev, libglm-dev
 Description: Magnum Integration development files
  Headers and tools needed for developing with Magnum Integration libraries.
 

--- a/package/gentoo/dev-libs/magnum-integration/magnum-integration-9999.ebuild
+++ b/package/gentoo/dev-libs/magnum-integration/magnum-integration-9999.ebuild
@@ -13,6 +13,7 @@ KEYWORDS="~amd64 ~x86"
 IUSE=""
 
 RDEPEND="
+	dev-cpp/eigen
 	dev-libs/magnum
 	media-libs/glm
 	sci-physics/bullet
@@ -26,6 +27,7 @@ src_configure() {
 		-DCMAKE_BUILD_TYPE=Release
 		-DWITH_BULLET=ON
 		-DWITH_DART=OFF
+		-DWITH_EIGEN=ON
 		-DWITH_GLM=ON
 		-DWITH_IMGUI=OFF
 	)

--- a/package/homebrew/magnum-integration.rb
+++ b/package/homebrew/magnum-integration.rb
@@ -7,6 +7,7 @@ class MagnumIntegration < Formula
   head "git://github.com/mosra/magnum-integration.git"
 
   depends_on "cmake"
+  depends_on "eigen"
   depends_on "glm"
   depends_on "magnum"
   depends_on "bullet"
@@ -14,7 +15,7 @@ class MagnumIntegration < Formula
   def install
     system "mkdir build"
     cd "build" do
-      system "cmake", "-DCMAKE_BUILD_TYPE=Release", "-DCMAKE_INSTALL_PREFIX=#{prefix}", "-DWITH_BULLET=ON", "-DWITH_DART=OFF", "-DWITH_GLM=ON", "-DWITH_IMGUI=OFF", ".."
+      system "cmake", "-DCMAKE_BUILD_TYPE=Release", "-DCMAKE_INSTALL_PREFIX=#{prefix}", "-DWITH_BULLET=ON", "-DWITH_DART=OFF", "-DWITH_EIGEN=ON", "-DWITH_GLM=ON", "-DWITH_IMGUI=OFF", ".."
       system "cmake", "--build", "."
       system "cmake", "--build", ".", "--target", "install"
     end

--- a/src/Magnum/EigenIntegration/CMakeLists.txt
+++ b/src/Magnum/EigenIntegration/CMakeLists.txt
@@ -3,7 +3,6 @@
 #
 #   Copyright © 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018, 2019
 #             Vladimír Vondruš <mosra@centrum.cz>
-#   Copyright © 2018 Jonathan Hale <squareys@googlemail.com>
 #
 #   Permission is hereby granted, free of charge, to any person obtaining a
 #   copy of this software and associated documentation files (the "Software"),
@@ -24,26 +23,27 @@
 #   DEALINGS IN THE SOFTWARE.
 #
 
-if(WITH_BULLET)
-    add_subdirectory(BulletIntegration)
+find_package(Eigen3 REQUIRED)
+
+set(MagnumEigenIntegration_HEADERS
+    GeometryIntegration.h
+    Integration.h)
+
+# EigenIntegration library
+add_library(MagnumEigenIntegration INTERFACE)
+set_target_properties(MagnumEigenIntegration PROPERTIES
+    INTERFACE_INCLUDE_DIRECTORIES ${PROJECT_SOURCE_DIR}/src
+    INTERFACE_LINK_LIBRARIES "Magnum::Magnum;Eigen3::Eigen")
+
+# Force IDEs to display all header files in project view
+add_custom_target(MagnumEigenIntegration-headers SOURCES ${MagnumEigenIntegration_HEADERS})
+set_target_properties(MagnumEigenIntegration-headers PROPERTIES FOLDER "Magnum/EigenIntegration")
+
+install(FILES ${MagnumEigenIntegration_HEADERS} DESTINATION ${MAGNUM_INCLUDE_INSTALL_DIR}/EigenIntegration)
+
+if(BUILD_TESTS)
+    add_subdirectory(Test)
 endif()
 
-if(WITH_DART)
-    add_subdirectory(DartIntegration)
-endif()
-
-if(WITH_EIGEN)
-    add_subdirectory(EigenIntegration)
-endif()
-
-if(WITH_GLM)
-    add_subdirectory(GlmIntegration)
-endif()
-
-if(WITH_IMGUI)
-    add_subdirectory(ImGuiIntegration)
-endif()
-
-if(WITH_OVR)
-    add_subdirectory(OvrIntegration)
-endif()
+# Magnum Eigen integration target alias for superprojects
+add_library(MagnumIntegration::Eigen ALIAS MagnumEigenIntegration)

--- a/src/Magnum/EigenIntegration/CMakeLists.txt
+++ b/src/Magnum/EigenIntegration/CMakeLists.txt
@@ -24,6 +24,20 @@
 #
 
 find_package(Eigen3 REQUIRED)
+# We could drop this once we can use at least 3.3.1 (Ubuntu 16.04 has only 3.3
+# beta, which doesn't have this target yet), however for Travis and AppVeyor
+# we're using FindEigen3.cmake from the downloaded sources (because the
+# Eigen3Config.cmake, which produces the actual targets, is not there -- only
+# Eigen3Config.cmake.in). See the YML files for an extended rant. Also,
+# FindEigen3 only defines EIGEN3_INCLUDE_DIR, not even EIGEN3_INCLUDE_DIRS, so
+# be extra careful. I also wanted to set INTERFACE_SYSTEM_INCLUDE_DIRECTORIES
+# of MagnumEigenIntegration to ${EIGEN3_INCLUDE_DIR} to avoid this target
+# creation but that was ignored by CMake (?!). This works, tho.
+# http://eigen.tuxfamily.org/index.php?title=ChangeLog#Eigen_3.3.1
+if(NOT TARGET Eigen3::Eigen)
+    add_library(Eigen3::Eigen INTERFACE IMPORTED)
+    set_target_properties(Eigen3::Eigen PROPERTIES INTERFACE_INCLUDE_DIRECTORIES ${EIGEN3_INCLUDE_DIR})
+endif()
 
 set(MagnumEigenIntegration_HEADERS
     GeometryIntegration.h

--- a/src/Magnum/EigenIntegration/GeometryIntegration.h
+++ b/src/Magnum/EigenIntegration/GeometryIntegration.h
@@ -1,0 +1,125 @@
+#ifndef Magnum_EigenIntegration_GeometryIntegration_h
+#define Magnum_EigenIntegration_GeometryIntegration_h
+/*
+    This file is part of Magnum.
+
+    Copyright © 2010, 2011, 2012, 2012, 2014, 2015, 2016, 2017, 2018, 2019
+              Vladimír Vondruš <mosra@centrum.cz>
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included
+    in all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+/** @file
+@brief Conversion of Eigen geometry types
+
+Provides conversion for the following types:
+
+| Magnum type                           | Equivalent Eigen type             |
+| ------------------------------------- | --------------------------------- |
+| @ref Magnum::Math::Vector "Math::Vector<size, T>" | @m_class{m-dox-external} [Eigen::Translation<T, size>](https://eigen.tuxfamily.org/dox/classEigen_1_1Translation.html) |
+| @ref Magnum::Math::Quaternion "Math::Quaternion<T>" | @m_class{m-dox-external} [Eigen::Quaternion<T>](https://eigen.tuxfamily.org/dox/classEigen_1_1Quaternion.html) |
+| @ref Magnum::Math::Matrix3x2<T> "Math::Matrix3x2<T>" | @m_class{m-dox-external} [Eigen::Transform<T, 2, AffineCompact>](https://eigen.tuxfamily.org/dox/classEigen_1_1Transform.html) |
+| @ref Magnum::Math::Matrix3<T> "Math::Matrix3<T>" | @m_class{m-dox-external} [Eigen::Transform<T, 2, Affine>](https://eigen.tuxfamily.org/dox/classEigen_1_1Transform.html), \n @m_class{m-dox-external} [Eigen::Transform<T, 2, Projective>](https://eigen.tuxfamily.org/dox/classEigen_1_1Transform.html), \n @m_class{m-dox-external} [Eigen::Transform<T, 2, Isometry>](https://eigen.tuxfamily.org/dox/classEigen_1_1Transform.html) |
+| @ref Magnum::Math::Matrix4x3<T> "Math::Matrix4x3<T>" | @m_class{m-dox-external} [Eigen::Transform<T, 3, AffineCompact>](https://eigen.tuxfamily.org/dox/classEigen_1_1Transform.html) |
+| @ref Magnum::Math::Matrix4<T> "Math::Matrix4<T>" | @m_class{m-dox-external} [Eigen::Transform<T, 3, Affine>](https://eigen.tuxfamily.org/dox/classEigen_1_1Transform.html), \n @m_class{m-dox-external} [Eigen::Transform<T, 3, Projective>](https://eigen.tuxfamily.org/dox/classEigen_1_1Transform.html), \n @m_class{m-dox-external} [Eigen::Transform<T, 3, Isometry>](https://eigen.tuxfamily.org/dox/classEigen_1_1Transform.html) |
+
+See @ref Magnum/EigenIntegration/Integration.h for conversion of basic matrix
+and vector types. Example usage:
+
+@snippet EigenIntegration.cpp GeometryIntegration
+
+@see @ref types-thirdparty-integration
+
+*/
+
+#include <Eigen/Geometry>
+#include <Magnum/Math/Quaternion.h>
+
+#include "Magnum/EigenIntegration/Integration.h"
+
+namespace Magnum { namespace Math { namespace Implementation {
+
+template<std::size_t size, class T> struct VectorConverter<size, T, Eigen::Translation<T, int(size)>> {
+    static Vector<size, T> from(const Eigen::Translation<T, size>& other) {
+        return Vector<size, T>(other.vector());
+    }
+
+    static Eigen::Translation<T, size> to(const Vector<size, T>& other) {
+        /* Can't use explicit conversion because of the all-catching implicit
+           constructor of Eigen::Matrix */
+        return Eigen::Translation<T, size>(VectorConverter<size, T, Eigen::Matrix<T, size, 1>>::to(other));
+    }
+};
+
+template<std::size_t size, class T, int mode> struct RectangularMatrixConverter<size, size, T, Eigen::Transform<T, int(size - 1), mode>> {
+    static_assert(mode == Eigen::Affine || mode == Eigen::Projective || mode == Eigen::Isometry,
+        "only Affine, Projective and Isometry transform supported");
+
+    static RectangularMatrix<size, size, T> from(const Eigen::Transform<T, int(size - 1), mode>& other) {
+        return RectangularMatrix<size, size, T>(other.matrix());
+    }
+
+    static Eigen::Transform<T, int(size - 1), mode> to(const RectangularMatrix<size, size, T>& other) {
+        /* Can't use explicit conversion because of the all-catching implicit
+           constructor of Eigen::Matrix */
+        return Eigen::Transform<T, int(size - 1), mode>(RectangularMatrixConverter<size, size, T, Eigen::Matrix<T, size, size>>::to(other));
+    }
+};
+
+/* Can't have templated on size like RectangularMatrixConverter<size + 1, size,
+   T, Eigen::Transform<T, int(size), Eigen::AffineCompact>> because error:
+   template argument ‘(size + 1)’ involves template parameter(s). ¯\_(ツ)_/¯
+   So duplicating for 2D and 3D here. */
+template<class T> struct RectangularMatrixConverter<3, 2, T, Eigen::Transform<T, 2, Eigen::AffineCompact>> {
+    static RectangularMatrix<3, 2, T> from(const Eigen::Transform<T, 2, Eigen::AffineCompact>& other) {
+        return RectangularMatrix<3, 2, T>(other.matrix());
+    }
+
+    static Eigen::Transform<T, 2, Eigen::AffineCompact> to(const RectangularMatrix<3, 2, T>& other) {
+        /* Can't use explicit conversion because of the all-catching implicit
+           constructor of Eigen::Matrix */
+        return Eigen::Transform<T, 2, Eigen::AffineCompact>(RectangularMatrixConverter<3, 2, T, Eigen::Matrix<T, 2, 3>>::to(other));
+    }
+};
+template<class T> struct RectangularMatrixConverter<4, 3, T, Eigen::Transform<T, 3, Eigen::AffineCompact>> {
+    static RectangularMatrix<4, 3, T> from(const Eigen::Transform<T, 3, Eigen::AffineCompact>& other) {
+        return RectangularMatrix<4, 3, T>(other.matrix());
+    }
+
+    static Eigen::Transform<T, 3, Eigen::AffineCompact> to(const RectangularMatrix<4, 3, T>& other) {
+        /* Can't use explicit conversion because of the all-catching implicit
+           constructor of Eigen::Matrix */
+        return Eigen::Transform<T, 3, Eigen::AffineCompact>(RectangularMatrixConverter<4, 3, T, Eigen::Matrix<T, 3, 4>>::to(other));
+    }
+};
+
+template<class T> struct QuaternionConverter<T, Eigen::Quaternion<T>> {
+    static Quaternion<T> from(const Eigen::Quaternion<T>& other) {
+        return {{other.x(), other.y(), other.z()}, other.w()};
+    }
+
+    static Eigen::Quaternion<T> to(const Quaternion<T>& other) {
+        /* Eigen's quaternion constructor is ordered w x y z */
+        return {other.scalar(), other.vector().x(), other.vector().y(), other.vector().z()};
+    }
+};
+
+}}}
+
+#endif

--- a/src/Magnum/EigenIntegration/Integration.h
+++ b/src/Magnum/EigenIntegration/Integration.h
@@ -1,0 +1,201 @@
+#ifndef Magnum_EigenIntegration_Integration_h
+#define Magnum_EigenIntegration_Integration_h
+/*
+    This file is part of Magnum.
+
+    Copyright © 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018, 2019
+              Vladimír Vondruš <mosra@centrum.cz>
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included
+    in all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+/** @file
+@brief Conversion of Eigen array and matrix types
+
+Provides conversion for the following types:
+
+| Magnum vector type                             | Equivalent Eigen type    |
+| ---------------------------------------------- | ------------------------ |
+| @ref Magnum::Math::BoolVector "Math::BoolVector<size>" | @m_class{m-dox-external} [Eigen::Array<bool, size, 1>](https://eigen.tuxfamily.org/dox/classEigen_1_1Array.html) |
+| @ref Magnum::Math::Vector "Math::Vector<size, T>" and derived classes | @m_class{m-dox-external} [Eigen::Array<T, size, 1>](https://eigen.tuxfamily.org/dox/classEigen_1_1Array.html) |
+| @ref Magnum::Math::Vector "Math::Vector<size, T>" and derived classes | @m_class{m-dox-external} [Eigen::Matrix<T, size, 1>](https://eigen.tuxfamily.org/dox/classEigen_1_1Matrix.html) |
+
+| Magnum matrix type                             | Equivalent Eigen type    |
+| ---------------------------------------------- | ------------------------ |
+| @ref Magnum::Math::RectangularMatrix "Math::RectangularMatrix<cols, rows, T>" and derived classes | @m_class{m-flat} [Eigen::Array<T, rows, cols>](https://eigen.tuxfamily.org/dox/classEigen_1_1Array.html) |
+| @ref Magnum::Math::RectangularMatrix "Math::RectangularMatrix<cols, rows, T>" and derived classes | @m_class{m-flat} [Eigen::Matrix<T, rows, cols>](https://eigen.tuxfamily.org/dox/classEigen_1_1Matrix.html) |
+
+@m_class{m-block m-warning}
+
+@par Conversion to Eigen types
+    While creating Magnum types from Eigen types is done via the usual explicit
+    conversion, unlike with other libraries such as @ref Magnum::GlmIntegration "GLM"
+    the other direction has to be done a different way. Due to both
+    @m_class{m-dox-external} [Eigen::Array](https://eigen.tuxfamily.org/dox/classEigen_1_1Array.html)
+    and @m_class{m-dox-external} [Eigen::Matrix](https://eigen.tuxfamily.org/dox/classEigen_1_1Matrix.html)
+    having an [implicit all-catching constructor](https://github.com/eigenteam/eigen-git-mirror/blob/28728b910ed1e280aad4a4c9c46ef4ae2dddccc7/Eigen/src/Core/Array.h#L165-L172),
+    implementing such a conversion on Magnum side is not possible. To work
+    around that, there's a special
+    @ref Magnum::EigenIntegration::eigenCast() "EigenIntegration::eigenCast()"
+    function that does the job instead. See the snippet below for an usage
+    example.
+@par
+    This restriction does not apply to the geometry types such as
+    @m_class{m-dox-external} [Eigen::Quaternion](https://eigen.tuxfamily.org/dox/classEigen_1_1Quaternion.html)
+    or @m_class{m-dox-external} [Eigen::Transform](https://eigen.tuxfamily.org/dox/classEigen_1_1Transform.html).
+
+@cpp Eigen::Array @ce and @cpp Eigen::Matrix @ce classes provide a
+@ref std::iostream @cpp operator<< @ce overload, which means they're directly
+usable with @ref Corrade::Utility::Debug. Example usage:
+
+@snippet EigenIntegration.cpp Integration
+
+See @ref Magnum/EigenIntegration/GeometryIntegration.h for conversion of
+special geometry types.
+
+@see @ref types-thirdparty-integration
+*/
+
+#include <Magnum/Math/RectangularMatrix.h>
+#include <Eigen/Core>
+
+namespace Magnum {
+
+namespace Math { namespace Implementation {
+
+template<std::size_t size> struct BoolVectorConverter<size, Eigen::Array<bool, int(size), 1>> {
+    static BoolVector<size> from(const Eigen::Array<bool, size, 1>& other) {
+        BoolVector<size> out{NoInit};
+        for(std::size_t i = 0; i != size; ++i)
+            out.set(i, other(i, 0));
+        return out;
+    }
+
+    static Eigen::Array<bool, size, 1> to(const BoolVector<size>& other) {
+        /** @todo is there a NoInit tag or something? */
+        Eigen::Array<bool, size, 1> out;
+        for(std::size_t i = 0; i != size; ++i)
+            out(i, 0) = other[i];
+        return out;
+    }
+};
+
+template<std::size_t size, class T> struct VectorConverter<size, T, Eigen::Array<T, int(size), 1>> {
+    static Vector<size, T> from(const Eigen::Array<T, size, 1>& other) {
+        Vector<size, T> out{NoInit};
+        for(std::size_t i = 0; i != size; ++i)
+            out[i] = other(i, 0);
+        return out;
+    }
+
+    static Eigen::Array<T, size, 1> to(const Vector<size, T>& other) {
+        /** @todo is there a NoInit tag or something? */
+        Eigen::Array<T, size, 1> out;
+        for(std::size_t i = 0; i != size; ++i)
+            out(i, 0) = other[i];
+        return out;
+    }
+};
+
+template<std::size_t size, class T> struct VectorConverter<size, T, Eigen::Matrix<T, int(size), 1>> {
+    static Vector<size, T> from(const Eigen::Matrix<T, size, 1>& other) {
+        Vector<size, T> out{NoInit};
+        for(std::size_t i = 0; i != size; ++i)
+            out[i] = other(i, 0);
+        return out;
+    }
+
+    static Eigen::Matrix<T, size, 1> to(const Vector<size, T>& other) {
+        /** @todo is there a NoInit tag or something? */
+        Eigen::Matrix<T, size, 1> out;
+        for(std::size_t i = 0; i != size; ++i)
+            out(i, 0) = other[i];
+        return out;
+    }
+};
+
+template<std::size_t cols, std::size_t rows, class T> struct RectangularMatrixConverter<cols, rows, T, Eigen::Array<T, int(rows), int(cols)>> {
+    static RectangularMatrix<cols, rows, T> from(const Eigen::Array<T, rows, cols>& other) {
+        RectangularMatrix<cols, rows, T> out{NoInit};
+        for(std::size_t col = 0; col != cols; ++col)
+            for(std::size_t row = 0; row != rows; ++row)
+                out[col][row] = other(row, col);
+        return out;
+    }
+
+    static Eigen::Array<T, rows, cols> to(const RectangularMatrix<cols, rows, T>& other) {
+        /** @todo is there a NoInit tag or something? */
+        Eigen::Array<T, rows, cols> out;
+        for(std::size_t col = 0; col != cols; ++col)
+            for(std::size_t row = 0; row != rows; ++row)
+                out(row, col) = other[col][row];
+        return out;
+    }
+};
+
+template<std::size_t cols, std::size_t rows, class T> struct RectangularMatrixConverter<cols, rows, T, Eigen::Matrix<T, int(rows), int(cols)>> {
+    static RectangularMatrix<cols, rows, T> from(const Eigen::Matrix<T, rows, cols>& other) {
+        RectangularMatrix<cols, rows, T> out{NoInit};
+        for(std::size_t col = 0; col != cols; ++col)
+            for(std::size_t row = 0; row != rows; ++row)
+                out[col][row] = other(row, col);
+        return out;
+    }
+
+    static Eigen::Matrix<T, rows, cols> to(const RectangularMatrix<cols, rows, T>& other) {
+        /** @todo is there a NoInit tag or something? */
+        Eigen::Matrix<T, rows, cols> out;
+        for(std::size_t col = 0; col != cols; ++col)
+            for(std::size_t row = 0; row != rows; ++row)
+                out(row, col) = other[col][row];
+        return out;
+    }
+};
+
+}}
+
+namespace EigenIntegration {
+
+/**
+@brief Convert a Magnum type to Eigen type
+
+Due to the design of @m_class{m-dox-external} [Eigen::Array](https://eigen.tuxfamily.org/dox/classEigen_1_1Array.html)
+and @m_class{m-dox-external} [Eigen::Matrix](https://eigen.tuxfamily.org/dox/classEigen_1_1Matrix.html)
+classes, it's not possible to use the usual explicit conversion approach. See
+@ref Magnum/EigenIntegration/Integration.h for more information.
+*/
+template<class To, std::size_t cols, std::size_t rows, class T> inline To eigenCast(const Math::RectangularMatrix<cols, rows, T>& from) {
+    return Math::Implementation::RectangularMatrixConverter<cols, rows, T, To>::to(from);
+}
+
+/** @overload */
+template<class To, std::size_t size> inline To eigenCast(const Math::BoolVector<size>& from) {
+    return Math::Implementation::BoolVectorConverter<size, To>::to(from);
+}
+
+/** @overload */
+template<class To, std::size_t size, class T> inline To eigenCast(const Math::Vector<size, T>& from) {
+    return Math::Implementation::VectorConverter<size, T, To>::to(from);
+}
+
+}
+
+}
+
+#endif

--- a/src/Magnum/EigenIntegration/Integration.h
+++ b/src/Magnum/EigenIntegration/Integration.h
@@ -79,7 +79,12 @@ namespace Magnum {
 
 namespace Math { namespace Implementation {
 
-template<std::size_t size> struct BoolVectorConverter<size, Eigen::Array<bool, int(size), 1>> {
+template<std::size_t size> struct BoolVectorConverter<size, Eigen::Array<bool, int(size), 1
+    #ifdef CORRADE_MSVC2017_COMPATIBILITY
+    /* Otherwise neither MSVC 2015 nor 2017 is able to match the signature */
+    , 0, int(size), 1
+    #endif
+>> {
     static BoolVector<size> from(const Eigen::Array<bool, size, 1>& other) {
         BoolVector<size> out{NoInit};
         for(std::size_t i = 0; i != size; ++i)
@@ -96,7 +101,11 @@ template<std::size_t size> struct BoolVectorConverter<size, Eigen::Array<bool, i
     }
 };
 
-template<std::size_t size, class T> struct VectorConverter<size, T, Eigen::Array<T, int(size), 1>> {
+template<std::size_t size, class T> struct VectorConverter<size, T, Eigen::Array<T, int(size), 1
+    #ifdef CORRADE_MSVC2017_COMPATIBILITY
+    , 0, int(size), 1 /* See above */
+    #endif
+>> {
     static Vector<size, T> from(const Eigen::Array<T, size, 1>& other) {
         Vector<size, T> out{NoInit};
         for(std::size_t i = 0; i != size; ++i)
@@ -113,7 +122,11 @@ template<std::size_t size, class T> struct VectorConverter<size, T, Eigen::Array
     }
 };
 
-template<std::size_t size, class T> struct VectorConverter<size, T, Eigen::Matrix<T, int(size), 1>> {
+template<std::size_t size, class T> struct VectorConverter<size, T, Eigen::Matrix<T, int(size), 1
+    #ifdef CORRADE_MSVC2017_COMPATIBILITY
+    , 0, int(size), 1 /* See above */
+    #endif
+>> {
     static Vector<size, T> from(const Eigen::Matrix<T, size, 1>& other) {
         Vector<size, T> out{NoInit};
         for(std::size_t i = 0; i != size; ++i)
@@ -130,7 +143,11 @@ template<std::size_t size, class T> struct VectorConverter<size, T, Eigen::Matri
     }
 };
 
-template<std::size_t cols, std::size_t rows, class T> struct RectangularMatrixConverter<cols, rows, T, Eigen::Array<T, int(rows), int(cols)>> {
+template<std::size_t cols, std::size_t rows, class T> struct RectangularMatrixConverter<cols, rows, T, Eigen::Array<T, int(rows), int(cols)
+    #ifdef CORRADE_MSVC2017_COMPATIBILITY
+    , 0, int(rows), int(cols) /* See above */
+    #endif
+>> {
     static RectangularMatrix<cols, rows, T> from(const Eigen::Array<T, rows, cols>& other) {
         RectangularMatrix<cols, rows, T> out{NoInit};
         for(std::size_t col = 0; col != cols; ++col)
@@ -149,7 +166,11 @@ template<std::size_t cols, std::size_t rows, class T> struct RectangularMatrixCo
     }
 };
 
-template<std::size_t cols, std::size_t rows, class T> struct RectangularMatrixConverter<cols, rows, T, Eigen::Matrix<T, int(rows), int(cols)>> {
+template<std::size_t cols, std::size_t rows, class T> struct RectangularMatrixConverter<cols, rows, T, Eigen::Matrix<T, int(rows), int(cols)
+    #ifdef CORRADE_MSVC2017_COMPATIBILITY
+    , 0, int(rows), int(cols) /* See above */
+    #endif
+>> {
     static RectangularMatrix<cols, rows, T> from(const Eigen::Matrix<T, rows, cols>& other) {
         RectangularMatrix<cols, rows, T> out{NoInit};
         for(std::size_t col = 0; col != cols; ++col)

--- a/src/Magnum/EigenIntegration/Test/CMakeLists.txt
+++ b/src/Magnum/EigenIntegration/Test/CMakeLists.txt
@@ -3,7 +3,6 @@
 #
 #   Copyright © 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018, 2019
 #             Vladimír Vondruš <mosra@centrum.cz>
-#   Copyright © 2018 Jonathan Hale <squareys@googlemail.com>
 #
 #   Permission is hereby granted, free of charge, to any person obtaining a
 #   copy of this software and associated documentation files (the "Software"),
@@ -24,26 +23,5 @@
 #   DEALINGS IN THE SOFTWARE.
 #
 
-if(WITH_BULLET)
-    add_subdirectory(BulletIntegration)
-endif()
-
-if(WITH_DART)
-    add_subdirectory(DartIntegration)
-endif()
-
-if(WITH_EIGEN)
-    add_subdirectory(EigenIntegration)
-endif()
-
-if(WITH_GLM)
-    add_subdirectory(GlmIntegration)
-endif()
-
-if(WITH_IMGUI)
-    add_subdirectory(ImGuiIntegration)
-endif()
-
-if(WITH_OVR)
-    add_subdirectory(OvrIntegration)
-endif()
+corrade_add_test(EigenIntegrationTest IntegrationTest.cpp LIBRARIES MagnumEigenIntegration)
+corrade_add_test(EigenGeometryIntegrationTest GeometryIntegrationTest.cpp LIBRARIES MagnumEigenIntegration)

--- a/src/Magnum/EigenIntegration/Test/GeometryIntegrationTest.cpp
+++ b/src/Magnum/EigenIntegration/Test/GeometryIntegrationTest.cpp
@@ -1,0 +1,170 @@
+/*
+    This file is part of Magnum.
+
+    Copyright © 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018, 2019
+              Vladimír Vondruš <mosra@centrum.cz>
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included
+    in all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+#include <Corrade/TestSuite/Tester.h>
+#include <Magnum/Magnum.h>
+#include <Magnum/Math/Matrix3.h>
+#include <Magnum/Math/Matrix4.h>
+
+#include "Magnum/EigenIntegration/GeometryIntegration.h"
+
+namespace Magnum { namespace EigenIntegration { namespace Test { namespace {
+
+struct GeometryIntegrationTest: TestSuite::Tester {
+    explicit GeometryIntegrationTest();
+
+    void translation2D();
+    void translation3D();
+
+    void quaternion();
+
+    void transform2DAffine();
+    void transform2DIsometry();
+    void transform2DAffineCompact();
+    void transform3DProjective();
+    void transform3DAffineCompact();
+};
+
+GeometryIntegrationTest::GeometryIntegrationTest() {
+    addTests({&GeometryIntegrationTest::translation2D,
+              &GeometryIntegrationTest::translation3D,
+
+              &GeometryIntegrationTest::quaternion,
+
+              &GeometryIntegrationTest::transform2DAffine,
+              &GeometryIntegrationTest::transform2DIsometry,
+              &GeometryIntegrationTest::transform2DAffineCompact,
+              &GeometryIntegrationTest::transform3DProjective,
+              &GeometryIntegrationTest::transform3DAffineCompact});
+}
+
+using namespace Math::Literals;
+
+void GeometryIntegrationTest::translation2D() {
+    Vector2 a{0.3f, -1.3f};
+    Eigen::Translation2f b{0.3f, -1.3f};
+
+    CORRADE_COMPARE(Vector2{b}, a);
+    CORRADE_VERIFY(Eigen::Translation2f(a).isApprox(b));
+}
+
+void GeometryIntegrationTest::translation3D() {
+    Vector3d a{0.3, -1.3, 2.1};
+    Eigen::Translation3d b{0.3, -1.3, 2.1};
+
+    CORRADE_COMPARE(Vector3d{b}, a);
+    CORRADE_VERIFY(Eigen::Translation3d(a).isApprox(b));
+}
+
+void GeometryIntegrationTest::quaternion() {
+    Quaternion a{{1.0f, 3.1f, 1.2f}, 0.5f};
+    Eigen::Quaternionf b{0.5f, 1.0f, 3.1f, 1.2f};
+
+    CORRADE_COMPARE(Quaternion{b}, a);
+    CORRADE_VERIFY(Eigen::Quaternionf(a).isApprox(b));
+
+    /* Explicitly check the parts to avoid having the conversion done wrong
+       twice */
+    CORRADE_COMPARE(Vector3{Eigen::Vector3f{b.vec()}}, a.vector());
+}
+
+void GeometryIntegrationTest::transform2DAffine() {
+    Matrix3 a = Matrix3::translation({-1.5f, 0.3f})*
+        Matrix3::rotation(25.0_degf)*
+        Matrix3::scaling({1.23f, 2.0f});
+
+    auto b = Eigen::Affine2f::Identity();
+    /* Wtf, I would expect the following xforms to be added from the left */
+    b.translate(Eigen::Vector2f{-1.5f, 0.3f})
+     .rotate(Float(Rad(25.0_degf)))
+     .scale(Eigen::Vector2f{1.23f, 2.0f});
+
+    CORRADE_COMPARE(Matrix3(b), a);
+    CORRADE_VERIFY(Eigen::Affine2f(a).isApprox(b));
+}
+
+void GeometryIntegrationTest::transform2DIsometry() {
+    Matrix3d a = Matrix3d::translation({-1.5, 0.3})*
+        Matrix3d::rotation(37.0_deg);
+
+    auto b = Eigen::Isometry2d::Identity();
+    /* Wtf, I would expect the following xforms to be added from the left */
+    b.translate(Eigen::Vector2d{-1.5, 0.3})
+     .rotate(Double(Radd(37.0_deg)));
+
+    CORRADE_COMPARE(Matrix3d(b), a);
+    CORRADE_VERIFY(Eigen::Isometry2d(a).isApprox(b, 1.0e-7));
+}
+
+void GeometryIntegrationTest::transform2DAffineCompact() {
+    Matrix3 a = Matrix3::translation({-1.5f, 0.3f})*
+        Matrix3::rotation(25.0_degf)*
+        Matrix3::scaling({1.23f, 2.0f});
+    Matrix3x2 a32{a[0].xy(), a[1].xy(), a[2].xy()};
+
+    auto b = Eigen::AffineCompact2f::Identity();
+    /* Wtf, I would expect the following xforms to be added from the left */
+    b.translate(Eigen::Vector2f{-1.5f, 0.3f})
+     .rotate(Float(Rad(25.0_degf)))
+     .scale(Eigen::Vector2f{1.23f, 2.0f});
+
+    CORRADE_COMPARE(Matrix3x2(b), a32);
+    CORRADE_VERIFY(Eigen::AffineCompact2f(a32).isApprox(b));
+}
+
+void GeometryIntegrationTest::transform3DProjective() {
+    Matrix4 a = Matrix4::translation({-1.5f, 0.3f, 1.4f})*
+        Matrix4::rotationY(25.0_degf)*
+        Matrix4::scaling({-3.3f, 1.23f, 2.0f});
+
+    auto b = Eigen::Projective3f::Identity();
+    /* Wtf, I would expect the following xforms to be added from the left */
+    b.translate(Eigen::Vector3f{-1.5f, 0.3f, 1.4f})
+     .rotate(Eigen::AngleAxisf{Float(Rad(25.0_degf)), Eigen::Vector3f::UnitY()})
+     .scale(Eigen::Vector3f{-3.3f, 1.23f, 2.0f});
+
+    CORRADE_COMPARE(Matrix4(b), a);
+    CORRADE_VERIFY(Eigen::Projective3f(a).isApprox(b));
+}
+
+void GeometryIntegrationTest::transform3DAffineCompact() {
+    Matrix4d a = Matrix4d::translation({-1.5, 0.3, 1.4})*
+        Matrix4d::rotationY(25.0_deg)*
+        Matrix4d::scaling({-3.3, 1.23, 2.0});
+    Matrix4x3d a43{a[0].xyz(), a[1].xyz(), a[2].xyz(), a[3].xyz()};
+
+    auto b = Eigen::AffineCompact3d::Identity();
+    /* Wtf, I would expect the following xforms to be added from the left */
+    b.translate(Eigen::Vector3d{-1.5, 0.3, 1.4})
+     .rotate(Eigen::AngleAxisd{Double(Radd(25.0_deg)), Eigen::Vector3d::UnitY()})
+     .scale(Eigen::Vector3d{-3.3, 1.23, 2.0});
+
+    CORRADE_COMPARE(Matrix4x3d(b), a43);
+    CORRADE_VERIFY(Eigen::AffineCompact3d(a43).isApprox(b));
+}
+
+}}}}
+
+CORRADE_TEST_MAIN(Magnum::EigenIntegration::Test::GeometryIntegrationTest)

--- a/src/Magnum/EigenIntegration/Test/IntegrationTest.cpp
+++ b/src/Magnum/EigenIntegration/Test/IntegrationTest.cpp
@@ -1,0 +1,144 @@
+/*
+    This file is part of Magnum.
+
+    Copyright © 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018, 2019
+              Vladimír Vondruš <mosra@centrum.cz>
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included
+    in all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+#include <Corrade/TestSuite/Tester.h>
+#include <Magnum/Magnum.h>
+#include <Magnum/Math/Vector4.h>
+
+#include "Magnum/EigenIntegration/Integration.h"
+
+/* Eigen types don't have operator==, so I can't use them in CORRADE_COMPARE().
+   I could use CORRADE_VERIFY(actual.isApprox(expected)), but that would not
+   print the actual values on errors -- and since Eigen has ostream operator<<
+   overloads, it'd be nice to use them. That's why this atrocity -- basically
+   a copy of the TestSuite::Comparator, but for a custom pseudo type and using
+   isApprox() instead of ==. */
+namespace {
+    template<class> class EigenType;
+}
+
+namespace Corrade { namespace TestSuite {
+
+template<class T> class Comparator<EigenType<T>> {
+    public:
+        bool operator()(const T& actual, const T& expected) {
+            if(actual.isApprox(expected)) return true;
+
+            actualValue = &actual;
+            expectedValue = &expected;
+            return false;
+        }
+
+        void printErrorMessage(Utility::Error& e, const std::string& actual, const std::string& expected) const {
+            CORRADE_INTERNAL_ASSERT(actualValue && expectedValue);
+            e << "Values" << actual << "and" << expected << "are not the same, actual is\n       "
+            << *actualValue << Utility::Debug::newline << "        but expected\n       " << *expectedValue;
+        }
+
+    private:
+        const T* actualValue{};
+        const T* expectedValue{};
+};
+
+}}
+
+namespace Magnum { namespace EigenIntegration { namespace Test { namespace {
+
+struct IntegrationTest: TestSuite::Tester {
+    explicit IntegrationTest();
+
+    void boolVector();
+
+    void vectorArray();
+    void vectorMatrix();
+
+    void matrixArray();
+    void matrixMatrix();
+};
+
+IntegrationTest::IntegrationTest() {
+    addTests({&IntegrationTest::boolVector,
+
+              &IntegrationTest::vectorArray,
+              &IntegrationTest::vectorMatrix,
+
+              &IntegrationTest::matrixArray,
+              &IntegrationTest::matrixMatrix});
+}
+
+void IntegrationTest::boolVector() {
+    /** @todo does Eigen have typedefs for this? */
+    Math::BoolVector<4> a{0xa};
+    Eigen::Array<bool, 4, 1> b;
+    b << false, true, false, true;
+
+    CORRADE_COMPARE(Math::BoolVector<4>{b}, a);
+    CORRADE_COMPARE_AS((eigenCast<Eigen::Array<bool, 4, 1>>(a)), b, EigenType);
+}
+
+void IntegrationTest::vectorArray() {
+    Vector4 a{1.5f, 0.3f, -1.1f, 0.6f};
+    Eigen::Array4f b;
+    b << 1.5f, 0.3f, -1.1f, 0.6f;
+
+    CORRADE_COMPARE(Vector4{b}, a);
+    CORRADE_COMPARE_AS(eigenCast<Eigen::Array4f>(a), b, EigenType);
+}
+
+void IntegrationTest::vectorMatrix() {
+    Vector4i a{1, 0, -3, 4457};
+    Eigen::Vector4i b{1, 0, -3, 4457};
+
+    CORRADE_COMPARE(Vector4i{b}, a);
+    CORRADE_COMPARE_AS(eigenCast<Eigen::Vector4i>(a), b, EigenType);
+}
+
+void IntegrationTest::matrixArray() {
+    Matrix3x2 a{Vector2{1.5f, 0.3f},
+                Vector2{-1.1f, 0.6f},
+                Vector2{0.5f, 7.8f}};
+    Eigen::Array<float, 2, 3> b;
+    b << 1.5f, -1.1f, 0.5f,
+         0.3f, 0.6f, 7.8f;
+
+    CORRADE_COMPARE(Matrix3x2{b}, a);
+    CORRADE_COMPARE_AS((eigenCast<Eigen::Array<float, 2, 3>>(a)), b, EigenType);
+}
+
+void IntegrationTest::matrixMatrix() {
+    Matrix3x2d a{Vector2d{1.5, 0.3},
+                 Vector2d{-1.1, 0.6},
+                 Vector2d{0.5, 7.8}};
+    Eigen::Array<double, 2, 3> b;
+    b << 1.5, -1.1, 0.5,
+         0.3, 0.6, 7.8;
+
+    CORRADE_COMPARE(Matrix3x2d{b}, a);
+    CORRADE_COMPARE_AS((eigenCast<Eigen::Array<double, 2, 3>>(a)), b, EigenType);
+}
+
+}}}}
+
+CORRADE_TEST_MAIN(Magnum::EigenIntegration::Test::IntegrationTest)


### PR DESCRIPTION
Done from both the coding and documentation side, except that it's failing to build on MSVC and Travis does not want to trigger the builds for latest commits.

TODO: 

- [x] Convince Travis to build this, fix the remaining issues
- [x] Fix MSVC build
- [x] Clean up the dirty commits
- [x] Apply the following to Magnum post-merge:

```patch
diff --git a/doc/types.dox b/doc/types.dox
index d59abd9d9..677a2fd2a 100644
--- a/doc/types.dox
+++ b/doc/types.dox
@@ -216,6 +216,9 @@ documentation of each `Integration.h` header for details:
 
 -   Math-related Vulkan structures --- @ref Magnum/Vk/Integration.h, part of
     the @ref Vk library
+-   All Eigen types --- @ref Magnum/EigenIntegration/Integration.h and
+    @ref Magnum/EigenIntegration/GeometryIntegration.h, part of the
+    @ref EigenIntegration library
 -   All GLM types --- @ref Magnum/GlmIntegration/Integration.h,
     @ref Magnum/GlmIntegration/GtcIntegration.h and
     @ref Magnum/GlmIntegration/GtxIntegration.h, part of the

```