### PR TITLE
ImGuiIntegration: Update reference to Context::_texture after moving Context

### DIFF
--- a/src/Magnum/ImGuiIntegration/Context.cpp
+++ b/src/Magnum/ImGuiIntegration/Context.cpp
@@ -130,6 +130,11 @@ Context::Context(NoCreateT) noexcept: _context{nullptr}, _shader{NoCreate}, _tex
 
 Context::Context(Context&& other) noexcept: _context{other._context}, _shader{std::move(other._shader)}, _texture{std::move(other._texture)}, _vertexBuffer{std::move(other._vertexBuffer)}, _indexBuffer{std::move(other._indexBuffer)}, _timeline{std::move(other._timeline)}, _mesh{std::move(other._mesh)}, _supersamplingRatio{other._supersamplingRatio}, _eventScaling{other._eventScaling} {
     other._context = nullptr;
+    /* Update the pointer to _texture */
+    ImGuiContext* current = ImGui::GetCurrentContext();
+    ImGui::SetCurrentContext(_context);
+    ImGui::GetIO().Fonts->SetTexID(reinterpret_cast<ImTextureID>(&_texture));
+    ImGui::SetCurrentContext(current);
 }
 
 Context::~Context() {
@@ -150,6 +155,15 @@ Context& Context::operator=(Context&& other) noexcept {
     std::swap(_mesh, other._mesh);
     std::swap(_supersamplingRatio, other._supersamplingRatio);
     std::swap(_eventScaling, other._eventScaling);
+
+    /* Update the pointers to _texture */
+    ImGuiContext* current = ImGui::GetCurrentContext();
+    ImGui::SetCurrentContext(_context);
+    ImGui::GetIO().Fonts->SetTexID(reinterpret_cast<ImTextureID>(&_texture));
+    ImGui::SetCurrentContext(other._context);
+    ImGui::GetIO().Fonts->SetTexID(reinterpret_cast<ImTextureID>(&other._texture));
+    ImGui::SetCurrentContext(current);
+
     return *this;
 }
 

--- a/src/Magnum/ImGuiIntegration/Test/ContextGLTest.cpp
+++ b/src/Magnum/ImGuiIntegration/Test/ContextGLTest.cpp
@@ -259,6 +259,7 @@ void ContextGLTest::constructMove() {
     CORRADE_COMPARE(a.context(), nullptr);
     CORRADE_COMPARE(b.context(), context);
 
+    CORRADE_COMPARE(&b.atlasTexture(), ImGui::GetIO().Fonts->TexID);
     CORRADE_COMPARE(ImGui::GetCurrentContext(), context);
 
     Context c{{}};
@@ -267,8 +268,12 @@ void ContextGLTest::constructMove() {
 
     c = std::move(b);
     CORRADE_COMPARE(ImGui::GetCurrentContext(), cContext);
+    CORRADE_COMPARE(&b.atlasTexture(), ImGui::GetIO().Fonts->TexID);
+    ImGui::SetCurrentContext(c.context());
+    CORRADE_COMPARE(&c.atlasTexture(), ImGui::GetIO().Fonts->TexID);
 
     /* This should not blow up */
+    ImGui::SetCurrentContext(cContext);
     c.newFrame();
 
     MAGNUM_VERIFY_NO_GL_ERROR();


### PR DESCRIPTION
Hi @mosra !

As mentioned on #61, the move constructor needs to update the pointer to `_texture`, otherwise rendering breaks because it uses the then deinitialized texture memory.

Best,
Jonathan