### PR TITLE
ImGuiIntegration: Fix assertion when move assigning empty context

### DIFF
--- a/src/Magnum/ImGuiIntegration/Context.cpp
+++ b/src/Magnum/ImGuiIntegration/Context.cpp
@@ -158,10 +158,14 @@ Context& Context::operator=(Context&& other) noexcept {
 
     /* Update the pointers to _texture */
     ImGuiContext* current = ImGui::GetCurrentContext();
-    ImGui::SetCurrentContext(_context);
-    ImGui::GetIO().Fonts->SetTexID(reinterpret_cast<ImTextureID>(&_texture));
-    ImGui::SetCurrentContext(other._context);
-    ImGui::GetIO().Fonts->SetTexID(reinterpret_cast<ImTextureID>(&other._texture));
+    if(_context) {
+        ImGui::SetCurrentContext(_context);
+        ImGui::GetIO().Fonts->SetTexID(reinterpret_cast<ImTextureID>(&_texture));
+    }
+    if(other._context) {
+        ImGui::SetCurrentContext(other._context);
+        ImGui::GetIO().Fonts->SetTexID(reinterpret_cast<ImTextureID>(&other._texture));
+    }
     ImGui::SetCurrentContext(current);
 
     return *this;

--- a/src/Magnum/ImGuiIntegration/Test/ContextGLTest.cpp
+++ b/src/Magnum/ImGuiIntegration/Test/ContextGLTest.cpp
@@ -127,6 +127,7 @@ struct ContextGLTest: GL::OpenGLTester {
     void constructExistingContext();
     void constructExistingContextAddFont();
     void constructMove();
+    void moveAssignEmpty();
 
     void release();
 
@@ -153,6 +154,7 @@ ContextGLTest::ContextGLTest() {
               &ContextGLTest::constructExistingContext,
               &ContextGLTest::constructExistingContextAddFont,
               &ContextGLTest::constructMove,
+              &ContextGLTest::moveAssignEmpty,
 
               &ContextGLTest::release,
 
@@ -289,6 +291,25 @@ void ContextGLTest::constructMove() {
     c.drawFrame();
 
     MAGNUM_VERIFY_NO_GL_ERROR();
+}
+
+void ContextGLTest::moveAssignEmpty() {
+    Context a{NoCreate};
+    Context b{{}};
+
+    /* Move from empty */
+    b = std::move(a);
+    CORRADE_COMPARE(b.context(), nullptr);
+
+    /* Move into empty */
+    b = std::move(a);
+    CORRADE_COMPARE(a.context(), nullptr);
+
+    /* Move empty into empty */
+    Context c{NoCreate};
+    c = std::move(a);
+    CORRADE_COMPARE(a.context(), nullptr);
+    CORRADE_COMPARE(c.context(), nullptr);
 }
 
 void ContextGLTest::release() {


### PR DESCRIPTION
@mosra As discussed via gitter, here's the follow-up fix for #62 .

Best,
Jonathan.