### PR TITLE
ImGuiIntegrationTest: ShowTestWindow will be removed in v1.75

### DIFF
--- a/src/Magnum/ImGuiIntegration/Test/ApplicationTest.cpp
+++ b/src/Magnum/ImGuiIntegration/Test/ApplicationTest.cpp
@@ -105,7 +105,7 @@ void ApplicationTest::drawEvent() {
         stopTextInput();
     #endif
 
-    ImGui::ShowTestWindow();
+    ImGui::ShowDemoWindow();
 
     #ifndef CORRADE_TARGET_ANDROID
     /* Update application cursor */


### PR DESCRIPTION
ShowTestWindow was deprecated in v1.53 and will be removed in v1.75