### PR TITLE
Add usage hints to vector-math integrations.

### DIFF
--- a/doc/namespaces.dox
+++ b/doc/namespaces.dox
@@ -164,6 +164,21 @@ set(WITH_EIGEN ON CACHE BOOL "" FORCE)
 add_subdirectory(magnum-integration EXCLUDE_FROM_ALL)
 @endcode
 
+@section usage Usage
+
+EigenIntegration provides built in conversion between Eigen's types and Magnum's own types.
+For example, an @cb{.cpp} Eigen::Vector3f @ce can be easily cast to Magnum's equivalent
+@cb{.cpp} Vector3 @ce :
+
+@code{.cpp}
+#include <Magnum/EigenIntegration/Integration.h>
+
+Eigen::Vector3f a{1.0f, 2.0f, 3.0f};
+Vector3 b(a);
+
+auto c = Matrix4::rotation(Vector3(a), 35.0_degf);
+@endcode
+
 The integration routines are provided in the
 @ref Magnum/EigenIntegration/Integration.h and
 @ref Magnum/EigenIntegration/GeometryIntegration.h headers, see their
@@ -236,8 +251,8 @@ add_subdirectory(magnum-integration EXCLUDE_FROM_ALL)
 @section usage Usage
 
 GlmIntegration provides built in conversion between GLM's types and Magnum's own types.
-For example, a @cb{.cpp} glm::vec3 @ce can be easily cast to magnum's equivalent
-@cb{.cpp} Vector3<float> @ce :
+For example, a @cb{.cpp} glm::vec3 @ce can be easily cast to Magnum's equivalent
+@cb{.cpp} Vector3 @ce :
 
 @code{.cpp}
 #include <Magnum/GlmIntegration/Integration.h>

--- a/doc/namespaces.dox
+++ b/doc/namespaces.dox
@@ -198,6 +198,7 @@ documentation for more information. See also @ref building-integration and
     information.
 
 */
+
 /** @dir Magnum/GlmIntegration
  * @brief Namespace @ref Magnum::GlmIntegration
  */
@@ -232,6 +233,21 @@ set(WITH_GLM ON CACHE BOOL "" FORCE)
 add_subdirectory(magnum-integration EXCLUDE_FROM_ALL)
 @endcode
 
+@section usage Usage
+
+GlmIntegration provides built in conversion between GLM's types and Magnum's own types.
+For example, a @cb{.cpp} glm::vec3 @ce can be easily cast to magnum's equivalent
+@cb{.cpp} Vector3<float> @ce :
+
+@code{.cpp}
+#include <Magnum/GlmIntegration/Integration.h>
+
+glm::vec3 a{1.0f, 2.0f, 3.0f};
+Vector3 b(a);
+
+auto c = Matrix4::rotation(35.0_degf, Vector3(a));
+@endcode
+
 The integration routines are provided in @ref Magnum/GlmIntegration/Integration.h,
 @ref Magnum/GlmIntegration/GtcIntegration.h and
 @ref Magnum/GlmIntegration/GtxIntegration.h headers, see their documentation
@@ -259,6 +275,7 @@ for more information. See also @ref building-integration and
     before including the file. See @ref singles and @ref Math for more
     information.
 */
+
 /** @namespace glm
 @brief GLM namespace.
 


### PR DESCRIPTION
This PR request adds short explanations of the functionality included in GlmIntegration and EigenIntegration. This should make it more obvious that both allow for casting to and from Magnum's native vector types. It should also make it more clear which headers must be included to take advantage of this functionality.

Short examples of the syntax are adapted from the blog post that explained the integration features when they were first introduced.