### PR TITLE
ImGuiIntegration: allow hiding the cursor

### DIFF
--- a/src/Magnum/ImGuiIntegration/Context.hpp
+++ b/src/Magnum/ImGuiIntegration/Context.hpp
@@ -260,6 +260,9 @@ template<class Application> void Context::updateApplicationCursor(Application& a
         case ImGuiMouseCursor_Hand:
             application.setCursor(Application::Cursor::Hand);
             return;
+        case ImGuiMouseCursor_None:
+            application.setCursor(Application::Cursor::Hidden);
+            return;
 
         /* For unknown cursors we set Arrow as well */
         case ImGuiMouseCursor_Arrow:

--- a/src/Magnum/ImGuiIntegration/Test/ContextGLTest.cpp
+++ b/src/Magnum/ImGuiIntegration/Test/ContextGLTest.cpp
@@ -71,6 +71,7 @@ struct Application {
     enum class Cursor {
         Arrow,
         Hand,
+        Hidden,
         TextInput,
         ResizeAll,
         ResizeWE,
@@ -664,7 +665,7 @@ void ContextGLTest::updateCursor() {
     CORRADE_VERIFY(app.currentCursor == Application::Cursor::Hand);
 
     /* Change to a cursor that is unknown -> fallback to an arrow */
-    ImGui::SetMouseCursor(ImGuiMouseCursor_None);
+    ImGui::SetMouseCursor(ImGuiMouseCursor_COUNT);
     c.updateApplicationCursor(app);
     CORRADE_VERIFY(app.currentCursor == Application::Cursor::Arrow);
 


### PR DESCRIPTION
Small change that allows hiding the cursor with `ImGui::SetMouseCursor(ImGuiMouseCursor_None)`. Also updated the test to not assume that `ImGuiMouseCursor_None` is unknown.