### PR TITLE
modules: fix linking error when build with latest imgui

### DIFF
--- a/modules/FindImGui.cmake
+++ b/modules/FindImGui.cmake
@@ -148,7 +148,7 @@ foreach(_component IN LISTS ImGui_FIND_COMPONENTS)
             set(ImGui_Sources_FOUND TRUE)
             set(ImGui_SOURCES )
 
-            foreach(_file imgui imgui_widgets imgui_draw imgui_demo)
+            foreach(_file imgui imgui_tables imgui_widgets imgui_draw imgui_demo)
                 # Disable the find root path here, it overrides the
                 # CMAKE_FIND_ROOT_PATH_MODE_INCLUDE setting potentially set in
                 # toolchains.


### PR DESCRIPTION
modules: fix `ImGui::TableSettingsInstallHandler(ImGuiContext*)` not found when building with latest version of imgui

ImGui's tables feature has been merged into master since [9874077](https://github.com/ocornut/imgui/commit/9874077fc0e364383ef997e3d4332172bfddc0b9), and the tables impl was moved into imgui_tables.cpp