### PR TITLE
ImGuiIntegration: fix indexing into KeysDown

### DIFF
--- a/src/Magnum/ImGuiIntegration/Context.cpp
+++ b/src/Magnum/ImGuiIntegration/Context.cpp
@@ -57,6 +57,8 @@ Context::Context(ImGuiContext& context, const Vector2& size, const Vector2i& win
     /* Ensure we use the context we're linked to */
     ImGui::SetCurrentContext(&context);
 
+    ImGuiIO &io = ImGui::GetIO();
+
     /* The KeyMap is meant to be for mapping from engine-native zero-based
        enums to ImGui enums in order to avoid complex switch-case and allow
        users to use native enums with ImGui input APIs. However Magnum only
@@ -64,28 +66,16 @@ Context::Context(ImGuiContext& context, const Vector2& size, const Vector2i& win
        generally not zero-based, so we need a switch-case in Context.hpp and
        the below mapping looks kinda suspicious. Should get revisited once
        there are changes in ImGui event handling code. Related discussion:
-       https://github.com/ocornut/imgui/pull/2269#issuecomment-453485633 */
-    ImGuiIO &io = ImGui::GetIO();
-    io.KeyMap[ImGuiKey_Tab]        = ImGuiKey_Tab;
-    io.KeyMap[ImGuiKey_LeftArrow]  = ImGuiKey_LeftArrow;
-    io.KeyMap[ImGuiKey_RightArrow] = ImGuiKey_RightArrow;
-    io.KeyMap[ImGuiKey_UpArrow]    = ImGuiKey_UpArrow;
-    io.KeyMap[ImGuiKey_DownArrow]  = ImGuiKey_DownArrow;
-    io.KeyMap[ImGuiKey_PageUp]     = ImGuiKey_PageUp;
-    io.KeyMap[ImGuiKey_PageDown]   = ImGuiKey_PageDown;
-    io.KeyMap[ImGuiKey_Home]       = ImGuiKey_Home;
-    io.KeyMap[ImGuiKey_End]        = ImGuiKey_End;
-    io.KeyMap[ImGuiKey_Delete]     = ImGuiKey_Delete;
-    io.KeyMap[ImGuiKey_Backspace]  = ImGuiKey_Backspace;
-    io.KeyMap[ImGuiKey_Space]      = ImGuiKey_Space;
-    io.KeyMap[ImGuiKey_Enter]      = ImGuiKey_Enter;
-    io.KeyMap[ImGuiKey_Escape]     = ImGuiKey_Escape;
-    io.KeyMap[ImGuiKey_A]          = ImGuiKey_A;
-    io.KeyMap[ImGuiKey_C]          = ImGuiKey_C;
-    io.KeyMap[ImGuiKey_V]          = ImGuiKey_V;
-    io.KeyMap[ImGuiKey_X]          = ImGuiKey_X;
-    io.KeyMap[ImGuiKey_Y]          = ImGuiKey_Y;
-    io.KeyMap[ImGuiKey_Z]          = ImGuiKey_Z;
+       https://github.com/ocornut/imgui/pull/2269#issuecomment-453485633.
+       This entire mechanism is deprecated since 1.87:
+       https://github.com/ocornut/imgui/issues/4858
+       ImGuiKey entries now start at 512, which makes them unsuitable for
+       indexing directly into KeyMap, so we have to remap them to 0. */
+    /** @todo Add support for the new IO key handling introduced in 1.87 */
+    constexpr ImGuiKey KeysStart = ImGuiKey_Tab;
+    constexpr ImGuiKey KeysEnd = ImGuiKey_COUNT;
+    for(ImGuiKey key = KeysStart; key != KeysEnd; ++key)
+        io.KeyMap[key] = key - KeysStart;
 
     /* Tell ImGui that changing mouse cursors is supported */
     io.BackendFlags |= ImGuiBackendFlags_HasMouseCursors;

--- a/src/Magnum/ImGuiIntegration/Context.hpp
+++ b/src/Magnum/ImGuiIntegration/Context.hpp
@@ -48,85 +48,52 @@ template<class KeyEvent> bool Context::handleKeyEvent(KeyEvent& event, bool valu
 
     ImGuiIO &io = ImGui::GetIO();
 
+    /* Since 1.87 ImGuiKey entries don't start at 0, so we need to subtract
+       the first value to index into KeysDown:
+       https://github.com/ocornut/imgui/issues/4858 */
+    constexpr ImGuiKey KeysStart = ImGuiKey_Tab;
+
     switch(event.key()) {
         /* LCOV_EXCL_START */
-        case KeyEvent::Key::LeftShift:
-        case KeyEvent::Key::RightShift:
-            io.KeyShift = value;
-            break;
-        case KeyEvent::Key::LeftCtrl:
-        case KeyEvent::Key::RightCtrl:
-            io.KeyCtrl = value;
-            break;
-        case KeyEvent::Key::LeftAlt:
-        case KeyEvent::Key::RightAlt:
-            io.KeyAlt = value;
-            break;
-        case KeyEvent::Key::LeftSuper:
-        case KeyEvent::Key::RightSuper:
-            io.KeySuper = value;
-            break;
-        case KeyEvent::Key::Tab:
-            io.KeysDown[ImGuiKey_Tab] = value;
-            break;
-        case KeyEvent::Key::Up:
-            io.KeysDown[ImGuiKey_UpArrow] = value;
-            break;
-        case KeyEvent::Key::Down:
-            io.KeysDown[ImGuiKey_DownArrow] = value;
-            break;
-        case KeyEvent::Key::Left:
-            io.KeysDown[ImGuiKey_LeftArrow] = value;
-            break;
-        case KeyEvent::Key::Right:
-            io.KeysDown[ImGuiKey_RightArrow] = value;
-            break;
-        case KeyEvent::Key::Home:
-            io.KeysDown[ImGuiKey_Home] = value;
-            break;
-        case KeyEvent::Key::End:
-            io.KeysDown[ImGuiKey_End] = value;
-            break;
-        case KeyEvent::Key::PageUp:
-            io.KeysDown[ImGuiKey_PageUp] = value;
-            break;
-        case KeyEvent::Key::PageDown:
-            io.KeysDown[ImGuiKey_PageDown] = value;
-            break;
-        case KeyEvent::Key::Enter:
-        case KeyEvent::Key::NumEnter:
-            io.KeysDown[ImGuiKey_Enter] = value;
-            break;
-        case KeyEvent::Key::Esc:
-            io.KeysDown[ImGuiKey_Escape] = value;
-            break;
-        case KeyEvent::Key::Space:
-            io.KeysDown[ImGuiKey_Space] = value;
-            break;
-        case KeyEvent::Key::Backspace:
-            io.KeysDown[ImGuiKey_Backspace] = value;
-            break;
-        case KeyEvent::Key::Delete:
-            io.KeysDown[ImGuiKey_Delete] = value;
-            break;
-        case KeyEvent::Key::A:
-            io.KeysDown[ImGuiKey_A] = value;
-            break;
-        case KeyEvent::Key::C:
-            io.KeysDown[ImGuiKey_C] = value;
-            break;
-        case KeyEvent::Key::V:
-            io.KeysDown[ImGuiKey_V] = value;
-            break;
-        case KeyEvent::Key::X:
-            io.KeysDown[ImGuiKey_X] = value;
-            break;
-        case KeyEvent::Key::Y:
-            io.KeysDown[ImGuiKey_Y] = value;
-            break;
-        case KeyEvent::Key::Z:
-            io.KeysDown[ImGuiKey_Z] = value;
-            break;
+        #define _b(key) case KeyEvent::Key::Left ## key: \
+                        case KeyEvent::Key::Right ## key: \
+                            io.Key ## key = value; \
+                            break;
+        #define _c(key, target) case KeyEvent::Key::key: \
+                            io.KeysDown[ImGuiKey_ ## target - KeysStart] = value; \
+                            break;
+        #define _d(key) _c(key, key)
+
+        _b(Shift)
+        _b(Ctrl)
+        _b(Alt)
+        _b(Super)
+
+        _d(Tab)
+        _c(Up, UpArrow)
+        _c(Down, DownArrow)
+        _c(Left, LeftArrow)
+        _c(Right, RightArrow)
+        _d(Home)
+        _d(End)
+        _d(PageUp)
+        _d(PageDown)
+        _d(Enter)
+        _c(NumEnter, Enter)
+        _c(Esc, Escape)
+        _d(Space)
+        _d(Backspace)
+        _d(Delete)
+        _d(A)
+        _d(C)
+        _d(V)
+        _d(X)
+        _d(Y)
+        _d(Z)
+
+        #undef _b
+        #undef _c
+        #undef _d
         /* LCOV_EXCL_STOP */
 
         /* Unknown key, do nothing */


### PR DESCRIPTION
Somewhat bandaid-y fix for https://github.com/mosra/magnum-integration/issues/87. The tl;dr is that with imgui >1.86 `ImGuiKey_*` don't start at 0, so we need to subtract the first value to index `io.KeysDown` correctly.

This isn't a long-term fix since the whole `KeyMap` + `KeysDown` thing is deprecated and will be removed in the future.