### PR TITLE
ImGuiIntegration: add support for draw list user callbacks

### DIFF
--- a/src/Magnum/ImGuiIntegration/Context.cpp
+++ b/src/Magnum/ImGuiIntegration/Context.cpp
@@ -334,6 +334,16 @@ void Context::drawFrame() {
         for(std::int_fast32_t c = 0; c < cmdList->CmdBuffer.Size; ++c) {
             const ImDrawCmd* pcmd = &cmdList->CmdBuffer[c];
 
+            if(pcmd->UserCallback) {
+                /* User callback, registered via ImDrawList::AddCallback().
+                   ImDrawCallback_ResetRenderState is a special callback value
+                   used by the user to request the renderer to reset render
+                   state. We do not have anything to do here though. */
+                if(pcmd->UserCallback != ImDrawCallback_ResetRenderState)
+                    pcmd->UserCallback(cmdList, pcmd);
+                continue;
+            }
+
             GL::Renderer::setScissor(Range2Di{Range2D{
                 {pcmd->ClipRect.x, fbSize.y() - pcmd->ClipRect.w},
                 {pcmd->ClipRect.z, fbSize.y() - pcmd->ClipRect.y}}

--- a/src/Magnum/ImGuiIntegration/Test/ContextGLTest.cpp
+++ b/src/Magnum/ImGuiIntegration/Test/ContextGLTest.cpp
@@ -651,6 +651,14 @@ void ContextGLTest::mouseInput() {
     MouseScrollEvent scroll{{1.2f, -1.2f}, {17, 23}, {}};
     c.handleMouseScrollEvent(scroll);
     Utility::System::sleep(1);
+    /* https://github.com/ocornut/imgui/commit/e346059eef140c5a8611581f3e6c8b8816d6998e
+       This commit changed input trickling to also apply to mouse wheel events.
+       Since we always set the mouse position in handleMouseScrollEvent(), the
+       mouse wheel event happens one frame later now. */
+    #if IMGUI_VERSION_NUM >= 18722
+    c.newFrame();
+    c.drawFrame();
+    #endif
     c.newFrame();
     CORRADE_COMPARE(Vector2(ImGui::GetMousePos()), (Vector2{17.0f, 23.0f}));
     CORRADE_COMPARE_AS(ImGui::GetIO().MouseWheelH, 1.2f, Float);


### PR DESCRIPTION
Continuation of https://github.com/mosra/magnum-integration/pull/84 with tests

(*and an unrelated fix for a failing test in ImGui 1.88* :eyes:)

Closes https://github.com/mosra/magnum-integration/pull/84.