### PR TITLE
ImGui: Add support for ImGuiBackendFlags_HasSetMousePos and cleaner drawFrame() code

### DIFF
--- a/src/Magnum/ImGuiIntegration/Context.cpp
+++ b/src/Magnum/ImGuiIntegration/Context.cpp
@@ -85,6 +85,8 @@ Context::Context(ImGuiContext& context, const Vector2& size, const Vector2i& win
 
     /* Tell ImGui that changing mouse cursors is supported */
     io.BackendFlags |= ImGuiBackendFlags_HasMouseCursors;
+    /* We can honor io.WantSetMousePos requests */
+    io.BackendFlags |= ImGuiBackendFlags_HasSetMousePos;
 
     /* Check if we can support base vertex > 0 in draw commands */
     #if !(defined(MAGNUM_TARGET_WEBGL) && defined(MAGNUM_TARGET_GLES2))

--- a/src/Magnum/ImGuiIntegration/Context.cpp
+++ b/src/Magnum/ImGuiIntegration/Context.cpp
@@ -85,9 +85,7 @@ Context::Context(ImGuiContext& context, const Vector2& size, const Vector2i& win
 
     /* Tell ImGui that changing mouse cursors is supported */
     io.BackendFlags |= ImGuiBackendFlags_HasMouseCursors;
-    /* We can honor io.WantSetMousePos requests */
-    io.BackendFlags |= ImGuiBackendFlags_HasSetMousePos;
-
+    
     /* Check if we can support base vertex > 0 in draw commands */
     #if !(defined(MAGNUM_TARGET_WEBGL) && defined(MAGNUM_TARGET_GLES2))
     if(

--- a/src/Magnum/ImGuiIntegration/Context.cpp
+++ b/src/Magnum/ImGuiIntegration/Context.cpp
@@ -312,17 +312,17 @@ void Context::drawFrame() {
 
     ImGui::Render();
 
-    ImGuiIO& io = ImGui::GetIO();
-    const Vector2 fbSize = Vector2{io.DisplaySize}*Vector2{io.DisplayFramebufferScale};
-    if(!fbSize.product()) return;
-
     ImDrawData* drawData = ImGui::GetDrawData();
     CORRADE_INTERNAL_ASSERT(drawData); /* This is always valid after Render() */
-    drawData->ScaleClipRects(io.DisplayFramebufferScale);
+
+    const Vector2 fbSize = Vector2{drawData->DisplaySize}*Vector2{drawData->FramebufferScale};
+    if(!fbSize.product()) return;
+
+    drawData->ScaleClipRects(drawData->FramebufferScale);
 
     const Matrix3 projection =
         Matrix3::translation({-1.0f, 1.0f})*
-        Matrix3::scaling({2.0f/Vector2(io.DisplaySize)})*
+        Matrix3::scaling({2.0f/Vector2(drawData->DisplaySize)})*
         Matrix3::scaling({1.0f, -1.0f});
     _shader.setTransformationProjectionMatrix(projection);
 

--- a/src/Magnum/ImGuiIntegration/Context.h
+++ b/src/Magnum/ImGuiIntegration/Context.h
@@ -379,6 +379,20 @@ class MAGNUM_IMGUIINTEGRATION_EXPORT Context {
         explicit Context(ImGuiContext& context, const Vector2i& size);
 
         /**
+         * @brief TODO
+         *
+         * Implicitly fetches framebuffer and window size from the application instance
+         * Using this template constructor is preferable as it enables additional features based on given Application capabilities
+         */
+        template<class Application> explicit Context(const Vector2& size, const Application& application);
+
+        /**
+         * @brief TODO
+         *
+         */
+        template<class Application> explicit Context(ImGuiContext& context, const Vector2& size, const Application& application);
+
+        /**
          * @brief Construct without creating the underlying ImGui context
          *
          * This constructor also doesn't create any internal OpenGL objects,

--- a/src/Magnum/ImGuiIntegration/Context.hpp
+++ b/src/Magnum/ImGuiIntegration/Context.hpp
@@ -337,6 +337,12 @@ MAGNUM_IMGUIINTEGRATION_OPTIONAL_CURSOR(No)
 #undef MAGNUM_IMGUIINTEGRATION_OPTIONAL_CURSOR
 #endif
 
+    template<class... T> void callWarpCursor(const T&...) {}
+
+    template<class Application, class = decltype(&Application::warpCursor)>
+    void callWarpCursor(Application& application, const Vector2i& position) {
+        application.warpCursor(position);
+    }
 }
 
 template<class Application> void Context::updateApplicationCursor(Application& application) {
@@ -345,9 +351,8 @@ template<class Application> void Context::updateApplicationCursor(Application& a
 
     ImGuiIO& io = ImGui::GetIO();
 
-    if( io.WantSetMousePos )
-    {
-        application.warpCursor(Vector2i(Vector2(io.MousePos)*_supersamplingRatio));
+    if(io.WantSetMousePos) {
+        Implementation::callWarpCursor(application, Vector2i(Vector2(io.MousePos)/_eventScaling));
     }
 
     switch(ImGui::GetMouseCursor()) {

--- a/src/Magnum/ImGuiIntegration/Context.hpp
+++ b/src/Magnum/ImGuiIntegration/Context.hpp
@@ -351,7 +351,7 @@ MAGNUM_IMGUIINTEGRATION_OPTIONAL_CURSOR(No)
 #undef MAGNUM_IMGUIINTEGRATION_OPTIONAL_CURSOR
 #endif
 
-    template<class... T> constexpr static void callWarpCursor(const T&...) {}
+    template<class... T> static void callWarpCursor(const T&...) {}
 
     template<class Application, class = decltype(&Application::warpCursor)>
     static void callWarpCursor(Application& application, const Vector2i& position) {

--- a/src/Magnum/ImGuiIntegration/Context.hpp
+++ b/src/Magnum/ImGuiIntegration/Context.hpp
@@ -343,6 +343,13 @@ template<class Application> void Context::updateApplicationCursor(Application& a
     /* Ensure we use the context we're linked to */
     ImGui::SetCurrentContext(_context);
 
+    ImGuiIO& io = ImGui::GetIO();
+
+    if( io.WantSetMousePos )
+    {
+        application.warpCursor(Vector2i(Vector2(io.MousePos)*_supersamplingRatio));
+    }
+
     switch(ImGui::GetMouseCursor()) {
         case ImGuiMouseCursor_TextInput:
             application.setCursor(Application::Cursor::TextInput);

--- a/src/Magnum/ImGuiIntegration/Test/ContextGLTest.cpp
+++ b/src/Magnum/ImGuiIntegration/Test/ContextGLTest.cpp
@@ -114,11 +114,11 @@ struct Application {
         None = 999
     };
 
-    Cursor _currentCursor = Cursor::None;
-    Vector2i _mousePos;
+    Cursor currentCursor = Cursor::None;
+    Vector2i mousePos;
 
-    void setCursor(Cursor cursor) { _currentCursor = cursor; }
-    void warpCursor(const Vector2i& pos) { _mousePos = pos; }
+    void setCursor(Cursor cursor) { currentCursor = cursor; }
+    void warpCursor(const Vector2i& pos) { mousePos = pos; }
 };
 
 struct KeyEvent: public InputEvent {
@@ -761,47 +761,47 @@ void ContextGLTest::updateCursor() {
 
     /* Default (should be an arrow) */
     c.updateApplicationCursor(app);
-    CORRADE_VERIFY(app._currentCursor == Application::Cursor::Arrow);
+    CORRADE_VERIFY(app.currentCursor == Application::Cursor::Arrow);
 
     /* Change to a cursor that is present in all apps */
     ImGui::SetMouseCursor(ImGuiMouseCursor_Hand);
     c.updateApplicationCursor(app);
-    CORRADE_VERIFY(app._currentCursor == Application::Cursor::Hand);
+    CORRADE_VERIFY(app.currentCursor == Application::Cursor::Hand);
 
     /* Change to a cursor that is unknown -> fallback to an arrow */
     ImGui::SetMouseCursor(ImGuiMouseCursor_COUNT);
     c.updateApplicationCursor(app);
-    CORRADE_VERIFY(app._currentCursor == Application::Cursor::Arrow);
+    CORRADE_VERIFY(app.currentCursor == Application::Cursor::Arrow);
 
     /* Change to a cursor that is conditional but present in this app */
     ImGui::SetMouseCursor(ImGuiMouseCursor_ResizeAll);
     c.updateApplicationCursor(app);
-    CORRADE_VERIFY(app._currentCursor == Application::Cursor::ResizeAll);
+    CORRADE_VERIFY(app.currentCursor == Application::Cursor::ResizeAll);
 
     /* Change to a cursor that is conditional and not present -> fallback to
        an arrow */
     ImGui::SetMouseCursor(ImGuiMouseCursor_ResizeNESW);
     c.updateApplicationCursor(app);
-    CORRADE_VERIFY(app._currentCursor == Application::Cursor::Arrow);
+    CORRADE_VERIFY(app.currentCursor == Application::Cursor::Arrow);
 
     /* Change to imgui mouse pos and mark it as changed
        Account for 2x DPI scaling in equality check */
     ImGuiIO& io = ImGui::GetIO();
-    io.MousePos = ImVec2(10, 10);
+    io.MousePos = ImVec2(10, 15);
     io.WantSetMousePos = true;
     c.updateApplicationCursor(app);
-    CORRADE_VERIFY(app._mousePos == Vector2i(20, 20));
+    CORRADE_VERIFY(app.mousePos == Vector2i(20, 30));
 
     /* Change to imgui mouse pos without marking it as changed */
-    io.MousePos = ImVec2(50, 50);
+    io.MousePos = ImVec2(50, 0);
     io.WantSetMousePos = false;
     c.updateApplicationCursor(app);
-    CORRADE_VERIFY(app._mousePos == Vector2i(20, 20));
+    CORRADE_VERIFY(app.mousePos == Vector2i(20, 30));
 
     /* Mark mouse pos changed */
     io.WantSetMousePos = true;
     c.updateApplicationCursor(app);
-    CORRADE_VERIFY(app._mousePos == Vector2i(100, 100));
+    CORRADE_VERIFY(app.mousePos == Vector2i(100, 0));
     
 }
 


### PR DESCRIPTION
`io.WantSetMousePos` will never be set unless requested by the user in the config like so:
```
ImGui::GetIO().ConfigFlags |= ImGuiConfigFlags_NavEnableSetMousePos;
ImGui::GetIO().ConfigFlags |= ImGuiConfigFlags_NavEnableKeyboard;
```

Minor tidy in DrawFrame(), the values in the ImDrawData are set based on the ImGui::GetIO() values so they will be the same