### PR TITLE
ImGuiIntegration: fix imageButton() with 1.91.1 and up

### DIFF
--- a/src/Magnum/ImGuiIntegration/Test/WidgetsGLTest.cpp
+++ b/src/Magnum/ImGuiIntegration/Test/WidgetsGLTest.cpp
@@ -107,7 +107,11 @@ void WidgetsGLTest::imageButton() {
 
     c.newFrame();
 
-    ImGuiIntegration::imageButton(texture, {100, 100});
+    ImGuiIntegration::imageButton("button", texture, {100, 100},
+        {{}, Vector2{1.0f}}, Color4::yellow(), Color4::blue());
+
+    ImGuiIntegration::imageButton(texture, {100, 100},
+        {{}, Vector2{1.0f}}, 5, Color4::yellow(), Color4::blue());
 
     c.drawFrame();
 

--- a/src/Magnum/ImGuiIntegration/Test/WidgetsGLTest.cpp
+++ b/src/Magnum/ImGuiIntegration/Test/WidgetsGLTest.cpp
@@ -110,8 +110,12 @@ void WidgetsGLTest::imageButton() {
     ImGuiIntegration::imageButton("button", texture, {100, 100},
         {{}, Vector2{1.0f}}, Color4::yellow(), Color4::blue());
 
+    #ifdef MAGNUM_BUILD_DEPRECATED
+    CORRADE_IGNORE_DEPRECATED_PUSH
     ImGuiIntegration::imageButton(texture, {100, 100},
         {{}, Vector2{1.0f}}, 5, Color4::yellow(), Color4::blue());
+    CORRADE_IGNORE_DEPRECATED_POP
+    #endif
 
     c.drawFrame();
 

--- a/src/Magnum/ImGuiIntegration/Widgets.h
+++ b/src/Magnum/ImGuiIntegration/Widgets.h
@@ -62,6 +62,39 @@ inline void image(GL::Texture2D& texture, const Vector2& size,
 
 /**
 @brief ImageButton widget displaying a @ref GL::Texture2D
+@param id               Widget ID
+@param texture          Texture to display
+@param size             Widget size
+@param uvRange          UV range on the texture (covers the whole texture by
+    default)
+@param backgroundColor  Background color, default @cpp 0x00000000_rgbaf @ce
+@param tintColor        Tint color, default @cpp 0xffffffff_rgbaf @ce
+@m_since_latest
+*/
+inline bool imageButton(const char* id, GL::Texture2D& texture, const Vector2& size,
+    const Range2D& uvRange = {{}, Vector2{1.0f}},
+    const Color4& backgroundColor = {},
+    const Color4& tintColor = Color4{1.0f})
+{
+    /* Old function generating an implicit ID and taking frame padding from an
+       explicit variable was deprecated in 1.89 and removed in 1.91.1 */
+    #if IMGUI_VERSION_NUM >= 19110
+    return ImGui::ImageButton(id, static_cast<ImTextureID>(&texture), ImVec2(size), ImVec2(uvRange.topLeft()), ImVec2(uvRange.bottomRight()), ImColor(backgroundColor), ImColor(tintColor));
+    #else
+    /* This is not exactly the same since the old function pushes another ID
+       based on the texture ID, but we can't disable that. Just a best effort
+       to still use the user-provided widget ID. There is ImageButtonEx()
+       taking an explicit ID, but its signature doesn't seem stable. */
+    ImGui::PushID(id);
+    /* Negative padding uses the FramePadding style */
+    const bool ret = ImGui::ImageButton(static_cast<ImTextureID>(&texture), ImVec2(size), ImVec2(uvRange.topLeft()), ImVec2(uvRange.bottomRight()), -1, ImColor(backgroundColor), ImColor(tintColor));
+    ImGui::PopID();
+    return ret;
+    #endif
+}
+
+/**
+@brief ImageButton widget displaying a @ref GL::Texture2D
 @param texture          Texture to display
 @param size             Widget size
 @param uvRange          UV range on the texture (covers the whole texture by

--- a/src/Magnum/ImGuiIntegration/Widgets.h
+++ b/src/Magnum/ImGuiIntegration/Widgets.h
@@ -93,19 +93,15 @@ inline bool imageButton(const char* id, GL::Texture2D& texture, const Vector2& s
     #endif
 }
 
+#ifdef MAGNUM_BUILD_DEPRECATED
 /**
 @brief ImageButton widget displaying a @ref GL::Texture2D
-@param texture          Texture to display
-@param size             Widget size
-@param uvRange          UV range on the texture (covers the whole texture by
-    default)
-@param framePadding     Frame padding, negative values use the default frame
-    padding
-@param backgroundColor  Background color, default @cpp 0x00000000_rgbaf @ce
-@param tintColor        Tint color, default @cpp 0xffffffff_rgbaf @ce
-@m_since_{integration,2019,10}
+@m_deprecated_since_latest Using an implicit ID is no longer possible in newer
+    ImGui. Use @ref imageButton(const char*, GL::Texture2D&, const Vector2&, const Range2D&, const Color4&, const Color4&)
+    instead.
 */
-inline bool imageButton(GL::Texture2D& texture, const Vector2& size,
+CORRADE_DEPRECATED("use imageButton(const char*, GL::Texture2D&, const Vector2&, const Range2D&, const Color4&, const Color4&) instead") inline bool imageButton(
+    GL::Texture2D& texture, const Vector2& size,
     const Range2D& uvRange = {{}, Vector2{1.0f}}, Int framePadding = -1,
     const Color4& backgroundColor = {},
     const Color4& tintColor = Color4{1.0f})
@@ -129,6 +125,7 @@ inline bool imageButton(GL::Texture2D& texture, const Vector2& size,
     return ImGui::ImageButton(textureId, ImVec2(size), ImVec2(uvRange.topLeft()), ImVec2(uvRange.bottomRight()), framePadding, ImColor(backgroundColor), ImColor(tintColor));
     #endif
 }
+#endif
 
 }}
 

--- a/src/Magnum/ImGuiIntegration/Widgets.h
+++ b/src/Magnum/ImGuiIntegration/Widgets.h
@@ -77,7 +77,24 @@ inline bool imageButton(GL::Texture2D& texture, const Vector2& size,
     const Color4& backgroundColor = {},
     const Color4& tintColor = Color4{1.0f})
 {
-    return ImGui::ImageButton(static_cast<ImTextureID>(&texture), ImVec2(size), ImVec2(uvRange.topLeft()), ImVec2(uvRange.bottomRight()), framePadding, ImColor(backgroundColor), ImColor(tintColor));
+    const ImTextureID textureId = static_cast<ImTextureID>(&texture);
+    /* Old function generating an implicit ID and taking frame padding from an
+       explicit variable was deprecated in 1.89 and removed in 1.91.1. This is
+       identical to the obsoleted wrapper code still present (but commented
+       out) in 1.91.1. */
+    #if IMGUI_VERSION_NUM >= 19110
+    /* ImTextureID is already void* */
+    ImGui::PushID(textureId);
+    if(framePadding >= 0)
+        ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2(framePadding, framePadding));
+    const bool ret = imageButton("", texture, size, uvRange, backgroundColor, tintColor);
+    if(framePadding >= 0)
+        ImGui::PopStyleVar();
+    ImGui::PopID();
+    return ret;
+    #else
+    return ImGui::ImageButton(textureId, ImVec2(size), ImVec2(uvRange.topLeft()), ImVec2(uvRange.bottomRight()), framePadding, ImColor(backgroundColor), ImColor(tintColor));
+    #endif
 }
 
 }}


### PR DESCRIPTION
Based on https://github.com/mosra/magnum-integration/pull/109, with added backwards compatibility.

I deprecated the old `imageButton()` function, not sure if that's a good idea, so feel free to drop that commit.