### PR TITLE
Fix for ImGui breaking change: Use static cast instead of reinterpret cast for new ImTextureID

### DIFF
--- a/src/Magnum/ImGuiIntegration/Context.cpp
+++ b/src/Magnum/ImGuiIntegration/Context.cpp
@@ -316,7 +316,14 @@ void Context::drawFrame() {
 
             /* We're storing just texture IDs, so make a non-owning instance
                around it, and assume it's already created */
-            GL::Texture2D texture = GL::Texture2D::wrap(static_cast<std::uintptr_t>(pcmd->TextureId), GL::ObjectFlag::Created);
+            GL::Texture2D texture = GL::Texture2D::wrap(
+                #if IMGUI_VERSION_NUM >= 19131
+                    pcmd->TextureId,
+                #else
+                    reinterpret_cast<std::uintptr_t>(pcmd->TextureId),
+                #endif
+                    GL::ObjectFlag::Created);
+
             _shader
                 .bindTexture(texture)
                 .draw(_mesh);

--- a/src/Magnum/ImGuiIntegration/Context.cpp
+++ b/src/Magnum/ImGuiIntegration/Context.cpp
@@ -316,7 +316,7 @@ void Context::drawFrame() {
 
             /* We're storing just texture IDs, so make a non-owning instance
                around it, and assume it's already created */
-            GL::Texture2D texture = GL::Texture2D::wrap(reinterpret_cast<std::uintptr_t>(pcmd->TextureId), GL::ObjectFlag::Created);
+            GL::Texture2D texture = GL::Texture2D::wrap(static_cast<std::uintptr_t>(pcmd->TextureId), GL::ObjectFlag::Created);
             _shader
                 .bindTexture(texture)
                 .draw(_mesh);

--- a/src/Magnum/ImGuiIntegration/Widgets.h
+++ b/src/Magnum/ImGuiIntegration/Widgets.h
@@ -55,7 +55,11 @@ an implementation detail that might change in the future.
 @see @ref image(), @ref imageButton()
 */
 inline ImTextureID textureId(GL::Texture2D& texture) {
-    return static_cast<ImTextureID>(texture.id());
+    #if IMGUI_VERSION_NUM >= 19131
+        return texture.id();
+    #else
+        return reinterpret_cast<ImTextureID>(texture.id());
+    #endif
 }
 
 /**

--- a/src/Magnum/ImGuiIntegration/Widgets.h
+++ b/src/Magnum/ImGuiIntegration/Widgets.h
@@ -55,7 +55,7 @@ an implementation detail that might change in the future.
 @see @ref image(), @ref imageButton()
 */
 inline ImTextureID textureId(GL::Texture2D& texture) {
-    return reinterpret_cast<ImTextureID>(texture.id());
+    return static_cast<ImTextureID>(texture.id());
 }
 
 /**


### PR DESCRIPTION
Hello again.

Looks like another breaking imgui change from
https://github.com/ocornut/imgui/commit/92b94980c69ff3d3d7f5dc30c1c19abfb72db47e

Since the default ImTextureID is now Im64 instead of void* I believe we no longer need to reinterpret_cast as the type conversion could be done implicitly.
In any case I changed it to explicitly static_cast to the same types.
This compiles and works for my use-case.

Thanks.