### PR TITLE
Adding Jolt Physics integration as JoltIntegration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,12 +76,14 @@ include(CMakeDependentOption)
 # two+ years passed, and then I realized I should change to
 # MAGNUM_WITH_BLAHINTEGRATION to avoid confusion. Sorry it took two steps.)
 set(_MAGNUMINTEGRATION_DEPRECATED_UNPREFIXED_OPTIONS
+    USE_EMSCRIPTEN_PORTS_JOLT
     USE_EMSCRIPTEN_PORTS_BULLET
     BUILD_STATIC
     BUILD_STATIC_PIC
     BUILD_TESTS
     BUILD_GL_TESTS)
 set(_MAGNUMINTEGRATION_DEPRECATED_UNPREFIXED_UNSUFFIXED_OPTIONS
+    WITH_JOLT
     WITH_BULLET
     WITH_DART
     WITH_EIGEN
@@ -115,6 +117,7 @@ if(NOT DEFINED _MAGNUMINTEGRATION_ACCEPT_DEPRECATED_UNPREFIXED_UNSUFFIXED_OPTION
 endif()
 
 # Parts of the library
+option(MAGNUM_WITH_JOLTINTEGRATION "Build JoltIntegration library" OFF)
 option(MAGNUM_WITH_BULLETINTEGRATION "Build BulletIntegration library" OFF)
 option(MAGNUM_WITH_DARTINTEGRATION "Build DartIntegration library" OFF)
 option(MAGNUM_WITH_EIGENINTEGRATION "Build EigenIntegration library" OFF)

--- a/src/Magnum/CMakeLists.txt
+++ b/src/Magnum/CMakeLists.txt
@@ -67,6 +67,10 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/versionIntegration.h.cmake
 
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/versionIntegration.h DESTINATION ${MAGNUM_INCLUDE_INSTALL_DIR})
 
+if(MAGNUM_WITH_JOLTINTEGRATION)
+    add_subdirectory(JoltIntegration)
+endif()
+
 if(MAGNUM_WITH_BULLETINTEGRATION)
     add_subdirectory(BulletIntegration)
 endif()

--- a/src/Magnum/JoltIntegration/CMakeLists.txt
+++ b/src/Magnum/JoltIntegration/CMakeLists.txt
@@ -1,0 +1,107 @@
+#
+#   This file is part of Magnum.
+#
+#   Copyright © 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018, 2019,
+#               2020, 2021, 2022, 2023, 2024, 2025, 2026
+#             Vladimír Vondruš <mosra@centrum.cz>
+#   Copyright © 2013 Jan Dupal <dupal.j@gmail.com>
+#   Copyright © 2019 bowling-allie <allie.smith.epic@gmail.com>
+#   Copyright © 2026 Igal Alkon <igal@alkontek.com>
+#
+#   Permission is hereby granted, free of charge, to any person obtaining a
+#   copy of this software and associated documentation files (the "Software"),
+#   to deal in the Software without restriction, including without limitation
+#   the rights to use, copy, modify, merge, publish, distribute, sublicense,
+#   and/or sell copies of the Software, and to permit persons to whom the
+#   Software is furnished to do so, subject to the following conditions:
+#
+#   The above copyright notice and this permission notice shall be included
+#   in all copies or substantial portions of the Software.
+#
+#   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+#   THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+#   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+#   FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+#   DEALINGS IN THE SOFTWARE.
+#
+
+# IDE folder in VS, Xcode etc. CMake 3.12+, older versions have only the FOLDER
+# property that would have to be set on each target separately.
+set(CMAKE_FOLDER "Magnum/JoltIntegration")
+
+find_package(Magnum REQUIRED GL Shaders)
+
+if(NOT MAGNUM_USE_EMSCRIPTEN_PORTS_JOLT)
+    find_package(Jolt CONFIG REQUIRED)
+endif()
+
+if(MAGNUM_BUILD_STATIC)
+    set(MAGNUM_JOLTINTEGRATION_BUILD_STATIC 1)
+endif()
+
+set(MagnumJoltIntegration_SRCS
+    DebugDraw.cpp
+)
+
+set(MagnumJoltIntegration_HEADERS
+    DebugDraw.h
+    Integration.h
+    visibility.h)
+
+# JoltIntegration library
+add_library(MagnumJoltIntegration ${SHARED_OR_STATIC}
+    ${MagnumJoltIntegration_SRCS}
+    ${MagnumJoltIntegration_HEADERS})
+
+if(NOT MAGNUM_BUILD_STATIC)
+    # Force static visibility for the example executable (no DLL export/import)
+    target_compile_definitions(MagnumJoltIntegration PRIVATE MagnumJoltIntegration_EXPORTS)
+endif()
+
+set_target_properties(MagnumJoltIntegration PROPERTIES
+        CXX_STANDARD 17
+        CXX_STANDARD_REQUIRED ON
+        CXX_EXTENSIONS OFF)
+
+target_include_directories(MagnumJoltIntegration PUBLIC
+    ${PROJECT_SOURCE_DIR}/src
+    ${PROJECT_BINARY_DIR}/src)
+
+set_target_properties(MagnumJoltIntegration PROPERTIES DEBUG_POSTFIX "-d")
+
+if(NOT MAGNUM_JOLTINTEGRATION_BUILD_STATIC)
+    set_target_properties(MagnumJoltIntegration PROPERTIES
+            VERSION ${MAGNUMINTEGRATION_LIBRARY_VERSION}
+            SOVERSION ${MAGNUMINTEGRATION_LIBRARY_SOVERSION})
+elseif(MAGNUM_BUILD_STATIC_PIC)
+    set_target_properties(MagnumJoltIntegration PROPERTIES POSITION_INDEPENDENT_CODE ON)
+endif()
+
+target_link_libraries(MagnumJoltIntegration PUBLIC
+    Magnum::GL
+    Magnum::Magnum
+    Magnum::Shaders
+    Jolt::Jolt)
+
+# If we use the Emscripten port, no find_package() was called and the targets
+# are not defined.
+if(MAGNUM_USE_EMSCRIPTEN_PORTS_JOLT)
+    target_compile_options(MagnumJoltIntegration PUBLIC "SHELL:-s USE_JOLT=1")
+    target_link_options(MagnumJoltIntegration PUBLIC "SHELL:-s USE_JOLT=1")
+endif()
+
+install(TARGETS MagnumJoltIntegration
+    RUNTIME DESTINATION ${MAGNUM_BINARY_INSTALL_DIR}
+    LIBRARY DESTINATION ${MAGNUM_LIBRARY_INSTALL_DIR}
+    ARCHIVE DESTINATION ${MAGNUM_LIBRARY_INSTALL_DIR})
+install(FILES ${MagnumJoltIntegration_HEADERS} DESTINATION ${MAGNUM_INCLUDE_INSTALL_DIR}/JoltIntegration)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/configure.h DESTINATION ${MAGNUM_INCLUDE_INSTALL_DIR}/JoltIntegration)
+
+if(MAGNUM_BUILD_TESTS)
+    add_subdirectory(Test ${EXCLUDE_FROM_ALL_IF_TEST_TARGET})
+endif()
+
+# Magnum-Jolt integration target alias for super-projects
+add_library(MagnumIntegration::Jolt ALIAS MagnumJoltIntegration)

--- a/src/Magnum/JoltIntegration/DebugDraw.cpp
+++ b/src/Magnum/JoltIntegration/DebugDraw.cpp
@@ -1,0 +1,161 @@
+/*
+    This file is part of Magnum.
+
+    Copyright © 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018, 2019,
+                2020, 2021, 2022, 2023, 2024, 2025, 2026
+              Vladimír Vondruš <mosra@centrum.cz>
+    Copyright © 2026 Igal Alkon <igal@alkontek.com>
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included
+    in all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+#include "DebugDraw.h"
+
+#include <Corrade/Containers/GrowableArray.h>
+#include <Corrade/Containers/Array.h>
+#include <Magnum/Math/Color.h>
+
+namespace Magnum { namespace JoltIntegration {
+
+    Debug& operator<<(Debug& debug, const DebugDraw::Mode value) {
+        switch(value) {
+            #define _c(value) case DebugDraw::Mode::value: return debug << "JoltIntegration::DebugDraw::Mode::" #value;
+            _c(DrawWireframes)
+            _c(DrawAabbs)
+            _c(DrawConstraints)
+            _c(DrawContacts)
+            _c(DrawGetSupportFunction)
+            _c(DrawSupportDirection)
+            _c(DrawGetSupportingFace)
+            _c(DrawShape)
+            _c(DrawShapeWireframe)
+            _c(DrawBoundingBox)
+            _c(DrawCenterOfMassTransform)
+            _c(DrawWorldTransform)
+            _c(DrawVelocity)
+            _c(DrawMassAndInertia)
+            _c(DrawSleepStats)
+            _c(DrawSoftBodyVertices)
+            _c(DrawSoftBodyVertexVelocities)
+            _c(DrawSoftBodyEdgeConstraints)
+            _c(DrawSoftBodyBendConstraints)
+            _c(DrawSoftBodyVolumeConstraints)
+            _c(DrawSoftBodySkinConstraints)
+            _c(DrawSoftBodyLRAConstraints)
+            _c(DrawSoftBodyRods)
+            _c(DrawSoftBodyRodStates)
+            _c(DrawSoftBodyRodBendTwistConstraints)
+            _c(DrawSoftBodyPredictedBounds)
+            #undef _c
+        }
+        return debug << "JoltIntegration::DebugDraw::Mode(" << Debug::nospace
+            << Debug::hex << static_cast<UnsignedInt>(static_cast<Int>(value)) << Debug::nospace << ")";
+    }
+
+    DebugDraw::DebugDraw(const std::size_t initialBufferCapacity): _mesh{GL::MeshPrimitive::Lines} {
+    _mesh.addVertexBuffer(
+        _buffer,
+        0,
+        Shaders::VertexColorGL3D::Position{},
+        Shaders::VertexColorGL3D::Color4{});
+
+    arrayReserve(_bufferData, initialBufferCapacity * 2);
+}
+
+DebugDraw::DebugDraw(NoCreateT) noexcept
+    : _shader{NoCreate}, _buffer{NoCreate}, _mesh{NoCreate} {}
+
+DebugDraw::~DebugDraw() = default;
+
+void DebugDraw::DrawLine(JPH::RVec3Arg inFrom, JPH::RVec3Arg inTo, JPH::ColorArg inColor) {
+    const Vector3 from {inFrom.GetX(), inFrom.GetY(), inFrom.GetZ()};
+    const Vector3 to {inTo.GetX(), inTo.GetY(), inTo.GetZ()};
+
+    const Vector4 color {
+        static_cast<Float>(inColor.r) / 255.0f,
+        static_cast<Float>(inColor.g) / 255.0f,
+        static_cast<Float>(inColor.b) / 255.0f,
+        1.0f
+    };
+
+    arrayAppend(_bufferData, {
+        Vertex{from, color},
+        Vertex{to,   color}
+    });
+}
+
+void DebugDraw::DrawTriangle(JPH::RVec3Arg inV1, JPH::RVec3Arg inV2, JPH::RVec3Arg inV3,
+                             JPH::ColorArg inColor, ECastShadow inCastShadow) {
+    DrawLine(inV1, inV2, inColor);
+    DrawLine(inV2, inV3, inColor);
+    DrawLine(inV3, inV1, inColor);
+}
+
+void DebugDraw::DrawText3D(JPH::RVec3Arg, const std::string_view&, JPH::ColorArg, float) {
+    // not implemented yet
+}
+
+void DebugDraw::flush() {
+    if (_bufferData.isEmpty()) return;
+
+    _buffer.setData(_bufferData, GL::BufferUsage::DynamicDraw);
+    _mesh.setCount(_bufferData.size());
+
+    _shader
+        .setTransformationProjectionMatrix(_transformationProjectionMatrix)
+        .draw(_mesh);
+
+    arrayResize(_bufferData, 0);
+}
+
+DebugDraw& DebugDraw::setMode(const UnsignedInt mode) {
+    _mode = mode;
+    _drawSettings = JPH::BodyManager::DrawSettings{};
+
+    _drawSettings.mDrawGetSupportFunction = (_mode & static_cast<UnsignedInt>(Mode::DrawGetSupportFunction)) != 0;
+    _drawSettings.mDrawSupportDirection = (_mode & static_cast<UnsignedInt>(Mode::DrawSupportDirection)) != 0;
+    _drawSettings.mDrawGetSupportingFace = (_mode & static_cast<UnsignedInt>(Mode::DrawGetSupportingFace)) != 0;
+    _drawSettings.mDrawShape = (_mode & static_cast<UnsignedInt>(Mode::DrawShape)) != 0;
+    _drawSettings.mDrawShapeWireframe = (_mode & static_cast<UnsignedInt>(Mode::DrawShapeWireframe)) != 0;
+    _drawSettings.mDrawBoundingBox = (_mode & static_cast<UnsignedInt>(Mode::DrawBoundingBox)) != 0;
+    _drawSettings.mDrawCenterOfMassTransform = (_mode & static_cast<UnsignedInt>(Mode::DrawCenterOfMassTransform)) != 0;
+    _drawSettings.mDrawWorldTransform = (_mode & static_cast<UnsignedInt>(Mode::DrawWorldTransform)) != 0;
+    _drawSettings.mDrawVelocity = (_mode & static_cast<UnsignedInt>(Mode::DrawVelocity)) != 0;
+    _drawSettings.mDrawMassAndInertia = (_mode & static_cast<UnsignedInt>(Mode::DrawMassAndInertia)) != 0;
+    _drawSettings.mDrawSleepStats = (_mode & static_cast<UnsignedInt>(Mode::DrawSleepStats)) != 0;
+    _drawSettings.mDrawSoftBodyVertices = (_mode & static_cast<UnsignedInt>(Mode::DrawSoftBodyVertices)) != 0;
+    _drawSettings.mDrawSoftBodyVertexVelocities = (_mode & static_cast<UnsignedInt>(Mode::DrawSoftBodyVertexVelocities)) != 0;
+    _drawSettings.mDrawSoftBodyEdgeConstraints = (_mode & static_cast<UnsignedInt>(Mode::DrawSoftBodyEdgeConstraints)) != 0;
+    _drawSettings.mDrawSoftBodyBendConstraints = (_mode & static_cast<UnsignedInt>(Mode::DrawSoftBodyBendConstraints)) != 0;
+    _drawSettings.mDrawSoftBodyVolumeConstraints = (_mode & static_cast<UnsignedInt>(Mode::DrawSoftBodyVolumeConstraints)) != 0;
+    _drawSettings.mDrawSoftBodySkinConstraints = (_mode & static_cast<UnsignedInt>(Mode::DrawSoftBodySkinConstraints)) != 0;
+    _drawSettings.mDrawSoftBodyLRAConstraints = (_mode & static_cast<UnsignedInt>(Mode::DrawSoftBodyLRAConstraints)) != 0;
+    _drawSettings.mDrawSoftBodyRods = (_mode & static_cast<UnsignedInt>(Mode::DrawSoftBodyRods)) != 0;
+    _drawSettings.mDrawSoftBodyRodStates = (_mode & static_cast<UnsignedInt>(Mode::DrawSoftBodyRodStates)) != 0;
+    _drawSettings.mDrawSoftBodyRodBendTwistConstraints = (_mode & static_cast<UnsignedInt>(Mode::DrawSoftBodyRodBendTwistConstraints)) != 0;
+    _drawSettings.mDrawSoftBodyPredictedBounds = (_mode & static_cast<UnsignedInt>(Mode::DrawSoftBodyPredictedBounds)) != 0;
+
+    return *this;
+}
+
+const JPH::BodyManager::DrawSettings& DebugDraw::drawSettings() const {
+    return _drawSettings;
+}
+
+}}

--- a/src/Magnum/JoltIntegration/DebugDraw.h
+++ b/src/Magnum/JoltIntegration/DebugDraw.h
@@ -1,0 +1,202 @@
+#ifndef Magnum_JoltIntegration_DebugDraw_h
+#define Magnum_JoltIntegration_DebugDraw_h
+/*
+    This file is part of Magnum.
+
+    Copyright © 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018, 2019,
+                2020, 2021, 2022, 2023, 2024, 2025, 2026
+              Vladimír Vondruš <mosra@centrum.cz>
+    Copyright © 2026 Igal Alkon <igal@alkontek.com>
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included
+    in all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+/** @file
+ * @brief CLass @ref Magnum::JoltIntegration::DebugDraw
+ * Implementation of `JPH::DebugRenderer` for physics visualization in Jolt.
+ */
+#include <Jolt/Jolt.h>
+#include <Jolt/Renderer/DebugRenderer.h>
+#include <Jolt/Renderer/DebugRendererSimple.h>
+#include <Jolt/Physics/Body/BodyManager.h>
+
+#include <Corrade/Containers/Array.h>
+
+#include <Magnum/GL/Buffer.h>
+#include <Magnum/GL/Mesh.h>
+#include <Magnum/Math/Matrix4.h>
+#include <Magnum/Shaders/VertexColorGL.h>
+
+#include "visibility.h"
+
+namespace Magnum { namespace JoltIntegration {
+    /**
+     * @brief Jolt physics debug visualization
+     */
+    class MAGNUM_JOLTINTEGRATION_EXPORT DebugDraw : public JPH::DebugRendererSimple {
+    public:
+        /**
+         * @brief Debug mode
+         * @see @ref Modes, @ref setMode(), @ref drawWorldData()
+         */
+        enum class Mode: UnsignedInt {
+            /* Draw body wireframes (via PhysicsSystem::DrawBodies()) */
+            DrawWireframes = 1 << 0,
+            /* Draw AABBs for active bodies */
+            DrawAabbs = 1 << 1,
+            /* Draw constraints */
+            DrawConstraints = 1 << 2,
+            /* Draw contact points/normals */
+            DrawContacts = 1 << 3,
+            /* Draw the GetSupport() function, used for convex collision detection */
+            DrawGetSupportFunction = 1 << 4,
+            /* When drawing the support function, also draw which direction mapped to a specific support point */
+            DrawSupportDirection = 1 << 5,
+            /* Draw the faces that were found colliding during collision detection */
+            DrawGetSupportingFace = 1 << 6,
+            /* Draw the shapes of all bodies */
+            DrawShape = 1 << 7,
+            /* When mDrawShape is true and this is true, the shapes will be drawn in wireframe instead of solid. */
+            DrawShapeWireframe = 1 << 8,
+            /* Draw a bounding box per body */
+            DrawBoundingBox = 1 << 9,
+            /* Draw the center of mass for each body */
+            DrawCenterOfMassTransform = 1 << 10,
+            /* Draw the world transform (which can be different than the center of mass) for each body */
+            DrawWorldTransform = 1 << 11,
+            /* Draw the velocity vector for each body */
+            DrawVelocity = 1 << 12,
+            /* Draw the mass and inertia (as the box equivalent) for each body */
+            DrawMassAndInertia = 1 << 13,
+            /* Draw stats regarding the sleeping algorithm of each body */
+            DrawSleepStats = 1 << 14,
+            /* Draw the vertices of soft bodies */
+            DrawSoftBodyVertices = 1 << 15,
+            /* Draw the velocities of the vertices of soft bodies */
+            DrawSoftBodyVertexVelocities = 1 << 16,
+            /* Draw the edge constraints of soft bodies */
+            DrawSoftBodyEdgeConstraints = 1 << 17,
+            /* Draw the bend constraints of soft bodies */
+            DrawSoftBodyBendConstraints = 1 << 18,
+            /* Draw the volume constraints of soft bodies */
+            DrawSoftBodyVolumeConstraints = 1 << 19,
+            /* Draw the skin constraints of soft bodies */
+            DrawSoftBodySkinConstraints = 1 << 20,
+            /* Draw the LRA constraints of soft bodies */
+            DrawSoftBodyLRAConstraints = 1 << 21,
+            /* Draw the rods of soft bodies */
+            DrawSoftBodyRods = 1 << 22,
+            /* Draw the rod states (orientation and angular velocity) of soft bodies */
+            DrawSoftBodyRodStates = 1 << 23,
+            /* Draw the rod bend twist constraints of soft bodies */
+            DrawSoftBodyRodBendTwistConstraints = 1 << 24,
+            /* Draw the predicted bounds of soft bodies */
+            DrawSoftBodyPredictedBounds = 1 << 25
+        };
+
+        /**
+         * @brief Debug modes
+         * @see @ref setMode()
+         */
+        typedef Containers::EnumSet<Mode> Modes;
+
+        /**
+         * @brief Constructor
+         * @param initialBufferCapacity  Number of lines for which to reserve memory in the buffer vector.
+         *
+         * Sets up @ref Shaders::VertexColorGL3D, @ref GL::Buffer and
+         * @ref GL::Mesh for physics debug rendering.
+         */
+        explicit DebugDraw(std::size_t initialBufferCapacity = 0);
+
+        /**
+         * @brief Construct without creating the underlying OpenGL objects
+         *
+         * The constructed instance is equivalent to moved-from state. Useful
+         * for deferring the initialization to a later point, for example, if
+         * the OpenGL context is not yet created. Move another instance over it
+         * to make it useful.
+         */
+        explicit DebugDraw(NoCreateT) noexcept;
+
+        /** @brief Copying is not allowed */
+        DebugDraw(const DebugDraw&) = delete;
+
+        ~DebugDraw() override;
+
+        /** @brief Copying is not allowed */
+        DebugDraw& operator=(const DebugDraw&) = delete;
+
+        /**
+          * @brief Debug modes bitfield
+          * @see @ref setMode()
+          */
+        UnsignedInt mode() const { return _mode; }
+
+        /**
+         * @brief Set debug mode bitfield
+         * @return Reference to self (for method chaining)
+         *
+         * Use `static_cast<UnsignedInt>(Mode::XXX)` or bitwise OR.
+         * By default, nothing is enabled (`0`).
+         */
+        DebugDraw& setMode(UnsignedInt mode);
+
+        /** @brief Get DrawSettings populated from current modes */
+        const JPH::BodyManager::DrawSettings& drawSettings() const;
+
+        /** @brief Set the transformation projection matrix used for rendering */
+        DebugDraw& setTransformationProjectionMatrix(const Matrix4& matrix) {
+            _transformationProjectionMatrix = matrix;
+            return *this;
+        }
+
+        /** @brief Flush all accumulated debug lines to the GPU and draw them */
+        void flush();
+
+        void DrawLine(JPH::RVec3Arg inFrom, JPH::RVec3Arg inTo, JPH::ColorArg inColor) override;
+        void DrawTriangle(JPH::RVec3Arg inV1, JPH::RVec3Arg inV2, JPH::RVec3Arg inV3, JPH::ColorArg inColor,
+            ECastShadow inCastShadow) override;
+        void DrawText3D(JPH::RVec3Arg inPosition, const std::string_view& inString, JPH::ColorArg inColor,
+            float inHeight) override;
+
+private:
+    struct Vertex {
+        Vector3 position;
+        Vector4 color;
+    };
+
+    UnsignedInt _mode{};
+    JPH::BodyManager::DrawSettings _drawSettings{};
+
+    Matrix4 _transformationProjectionMatrix;
+    Shaders::VertexColorGL3D _shader;
+    GL::Buffer _buffer;
+    GL::Mesh _mesh;
+    Containers::Array<Vertex> _bufferData;
+};
+
+CORRADE_ENUMSET_OPERATORS(DebugDraw::Modes)
+
+/** @debugoperatorenum{Magnum::JoltIntegration::DebugDraw::Mode} */
+MAGNUM_JOLTINTEGRATION_EXPORT Debug& operator<<(Debug& debug, DebugDraw::Mode value);
+
+}}
+
+#endif

--- a/src/Magnum/JoltIntegration/Integration.h
+++ b/src/Magnum/JoltIntegration/Integration.h
@@ -1,0 +1,87 @@
+#ifndef Magnum_JoltIntegration_h
+#define Magnum_JoltIntegration_h
+/*
+    This file is part of Magnum.
+
+    Copyright © 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018, 2019,
+                2020, 2021, 2022, 2023, 2024, 2025, 2026
+              Vladimír Vondruš <mosra@centrum.cz>
+    Copyright © 2026 Igal Alkon <igal@alkontek.com>
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included
+    in all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+/**
+ * @file
+ * @brief Conversion of Jolt math types
+*/
+
+#include <Magnum/Math/RectangularMatrix.h>
+#include <Magnum/Math/Quaternion.h>
+
+/* Jolt requires <Jolt/Jolt.h> BEFORE any other Jolt header.
+We include the full definitions here because the converters return Jolt types by value. */
+#include <Jolt/Jolt.h>
+
+#ifndef DOXYGEN_GENERATING_OUTPUT
+
+namespace Magnum { namespace Math { namespace Implementation {
+
+    template<> struct VectorConverter<3, Float, JPH::Vec3> {
+        static Vector<3, Float> from(const JPH::Vec3& other) {
+            return {other.GetX(), other.GetY(), other.GetZ()};
+        }
+
+        static JPH::Vec3 to(const Vector<3, Float>& other) {
+            return {other[0], other[1], other[2]};
+        }
+    };
+
+    template<> struct RectangularMatrixConverter<4, 4, Float, JPH::Mat44> {
+        static RectangularMatrix<4, 4, Float> from(const JPH::Mat44& other) {
+            RectangularMatrix<4, 4, Float> result;
+            for (int row = 0; row < 4; ++row)
+                for (int col = 0; col < 4; ++col)
+                    result[col][row] = other(row, col);
+            return result;
+        }
+
+        static JPH::Mat44 to(const RectangularMatrix<4, 4, Float>& other) {
+            JPH::Mat44 result{};
+            for (int row = 0; row < 4; ++row)
+                for (int col = 0; col < 4; ++col)
+                    result(row, col) = other[col][row];
+            return result;
+        }
+    };
+
+    template<> struct QuaternionConverter<Float, JPH::Quat> {
+        static Quaternion<Float> from(const JPH::Quat& other) {
+            return {{other.GetX(), other.GetY(), other.GetZ()}, other.GetW()};
+        }
+
+        static JPH::Quat to(const Quaternion<Float>& other) {
+            return {other.vector().x(), other.vector().y(), other.vector().z(), other.scalar()};
+        }
+    };
+
+}}}
+#endif
+
+#endif //Magnum_JoltIntegration_h

--- a/src/Magnum/JoltIntegration/visibility.h
+++ b/src/Magnum/JoltIntegration/visibility.h
@@ -1,0 +1,48 @@
+#ifndef Magnum_JoltIntegration_visibility_h
+#define Magnum_JoltIntegration_visibility_h
+/*
+    This file is part of Magnum.
+
+    Copyright © 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018, 2019,
+                2020, 2021, 2022, 2023, 2024, 2025, 2026
+              Vladimír Vondruš <mosra@centrum.cz>
+    Copyright © 2026 Igal Alkon <igal@alkontek.com>
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included
+    in all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+#include <Corrade/Utility/VisibilityMacros.h>
+
+#ifndef DOXYGEN_GENERATING_OUTPUT
+#ifndef MAGNUM_JOLTINTEGRATION_BUILD_STATIC
+    #ifdef MagnumJoltIntegration_EXPORTS
+        #define MAGNUM_JOLTINTEGRATION_EXPORT CORRADE_VISIBILITY_EXPORT
+    #else
+        #define MAGNUM_JOLTINTEGRATION_EXPORT CORRADE_VISIBILITY_IMPORT
+    #endif
+#else
+    #define MAGNUM_JOLTINTEGRATION_EXPORT CORRADE_VISIBILITY_STATIC
+#endif
+#define MAGNUM_JOLTINTEGRATION_LOCAL CORRADE_VISIBILITY_LOCAL
+#else
+#define MAGNUM_JOLTINTEGRATION_EXPORT
+#define MAGNUM_JOLTINTEGRATION_LOCAL
+#endif
+
+#endif


### PR DESCRIPTION
Implemented integration with [JoltPhysics](https://github.com/jrouwe/JoltPhysics) similar to Bullet integration, without `MotionState` class.

This was tested on Windows and `vcpkg`:
```
vcpkg install joltphysics[debugrenderer,profiler]
```